### PR TITLE
Replaced condition = "true" for key bindings with condition = "1 == 1".

### DIFF
--- a/AGM_Core/scripts/KeyInput/initKeys.sqf
+++ b/AGM_Core/scripts/KeyInput/initKeys.sqf
@@ -34,5 +34,8 @@ _return = "_isInput";
 _onKeyDown = _onKeyDown + _return;
 _onKeyUp = _onKeyUp;
 
+//diag_log format ["AGM_Core_onKeyDown: %1", _onKeyDown];
+//diag_log format ["AGM_Core_onKeyUp: %1", _onKeyUp];
+
 AGM_Core_onKeyDown = compileFinal _onKeyDown;
 AGM_Core_onKeyUp = compileFinal _onKeyUp;

--- a/AGM_Hearing/config.cpp
+++ b/AGM_Hearing/config.cpp
@@ -33,7 +33,7 @@ class Extended_PostInit_EventHandlers {
 class AGM_Core_Default_Keys {
   class Earplugs {
     displayName = "$STR_AGM_Hearing_Earbuds_On";
-    condition = "true";
+    condition = "1 == 1";
     statement = "[] call AGM_Hearing_fnc_Earplugs";
     key = 18;
     shift = 0;

--- a/AGM_Interaction/config.cpp
+++ b/AGM_Interaction/config.cpp
@@ -34,8 +34,8 @@ class Extended_PostInit_EventHandlers {
 class AGM_Core_Default_Keys {
   class openInteractionMenu {
     displayName = "$STR_AGM_Interaction_InteractionMenu";
-    condition = "true";
-    statement = "if !dialog then {'' call AGM_Interaction_fnc_openMenu} else {closeDialog 0}";
+    condition = "1 == 1";
+    statement = "if (!dialog) then {'' call AGM_Interaction_fnc_openMenu;} else {closeDialog 0;}";
     key = 221;
     shift = 0;
     control = 0;
@@ -43,8 +43,8 @@ class AGM_Core_Default_Keys {
   };
   class openInteractionMenuSelf {
     displayName = "$STR_AGM_Interaction_InteractionMenuSelf";
-    condition = "true";
-    statement = "if !dialog then {'' call AGM_Interaction_fnc_openMenuSelf} else {closeDialog 0}";
+    condition = "1 == 1";
+    statement = "if (!dialog) then {'' call AGM_Interaction_fnc_openMenuSelf;} else {closeDialog 0;}";
     key = 221;
     shift = 0;
     control = 1;


### PR DESCRIPTION
If condition was set to "true", it was somehow evaluated to {} in initKey.sqf, which Arma evaluates to false. 
As a result, at least for me, interaction menus were not appearing.
This can be observed by uncommenting the diag_log lines in initKey.sqf.
With condition = "true":
  if (_keyCode == profileNamespace getVariable 'AGM_Key_openInteractionMenuSelf' && {}) then {...}
With condition = "1 == 1":
  if (_keyCode == profileNamespace getVariable 'AGM_Key_openInteractionMenuSelf' && {1 == 1}) then {...}
