### PR TITLE
Added AGM parameters. Closes #422 and  #389

### DIFF
--- a/AGM_Core/config.cpp
+++ b/AGM_Core/config.cpp
@@ -239,6 +239,12 @@ class CfgSounds {
   };
 };
 
+class Extended_PreInit_EventHandlers {
+  class AGM_Core {
+    serverInit = "call compile preprocessFileLineNumbers '\AGM_Core\scripts\readParameters.sqf'";
+  };
+};
+
 class Extended_PostInit_EventHandlers {
   class AGM_Core {
     Init = "call compile preprocessFileLineNumbers '\AGM_Core\init.sqf'";

--- a/AGM_Core/scripts/readParameters.sqf
+++ b/AGM_Core/scripts/readParameters.sqf
@@ -1,0 +1,23 @@
+// by CAA-Picard
+
+// Read AGM_Parameters from config and set them on the mission namespace
+_config = configFile >> "AGM_Parameters";
+_count = count _config;
+for "_index" from 0 to (_count - 1) do {
+  _x = _config select _index;
+
+  _name = configName _x;
+  _value = _x call bis_fnc_getcfgdata;
+  missionNamespace setVariable [_name, _value];
+};
+
+// Read AGM_Parameters from mission and set them on the mission namespace, replacing defaults if necesary
+_config = missionConfigFile >> "AGM_Parameters";
+_count = count _config;
+for "_index" from 0 to (_count - 1) do {
+  _x = _config select _index;
+
+  _name = configName _x;
+  _value = _x call bis_fnc_getcfgdata;
+  missionNamespace setVariable [_name, _value];
+};

--- a/AGM_Interaction/clientInit.sqf
+++ b/AGM_Interaction/clientInit.sqf
@@ -15,11 +15,7 @@ addMissionEventHandler ["Draw3D", {
 		_position = visiblePosition _target;
 		_position = _position vectorAdd [0, 0, _height];
 
-		_viewDistance = 5;
-		if !isNil("AGM_Interaction_PlayerNamesViewDistance") then {
-			_viewDistance = AGM_Interaction_PlayerNamesViewDistance;
-		};
-		_alpha = _viewDistance - (player distance _target);
+		_alpha = (missionNamespace getVariable "AGM_Interaction_PlayerNamesViewDistance") - (player distance _target);
 		_color = [1, 1, 1, _alpha];
 
 		drawIcon3D [

--- a/AGM_Interaction/config.cpp
+++ b/AGM_Interaction/config.cpp
@@ -86,6 +86,10 @@ class AGM_Core_Options {
   };
 };
 
+class AGM_Parameters {
+  AGM_Interaction_PlayerNamesViewDistance = 5;
+};
+
 class CfgVehicles {
   class Man;
 

--- a/AGM_Interaction/functions/fn_module.sqf
+++ b/AGM_Interaction/functions/fn_module.sqf
@@ -1,0 +1,24 @@
+/*
+ * Author: CAA-Picard
+ *
+ * Initializes the interaction module.
+ *
+ * Arguments:
+ * Whatever the module provides.
+ *
+ * Return Value:
+ * None
+ */
+if !(isServer) exitWith {};
+
+_logic = _this select 0;
+_units = _this select 1;
+_activated = _this select 2;
+
+if !(_activated) exitWith {};
+
+AGM_Interaction_Module = true;
+
+missionNamespace setVariable ["AGM_Interaction_PlayerNamesViewDistance", parseNumber (_logic getVariable "PlayerNamesViewDistance")];
+
+diag_log text "AGM: Interaction Module Initialized.";


### PR DESCRIPTION
Added AGM_Parameters. They are initialized by the server with default values from config and can be overrided on description.ext or modified at runtime. Closes #422

Also added customization of player names view distance. Closes #389
