### PR TITLE
Changed order of Ghosthawk turret classes

### DIFF
--- a/AGM_Aircraft/config.cpp
+++ b/AGM_Aircraft/config.cpp
@@ -809,8 +809,8 @@ class CfgVehicles {
   };
   class Heli_Transport_01_base_F: Helicopter_Base_H {
     class Turrets: Turrets {
-      class MainTurret: MainTurret {};
       class CopilotTurret: CopilotTurret {};
+      class MainTurret: MainTurret {};
       class RightDoorGun;
     };
   };
@@ -969,11 +969,11 @@ class CfgVehicles {
     incomingMissileDetectionSystem = 16;
     driverCanEject = 1;
     class Turrets: Turrets {
-      class MainTurret: MainTurret {
-        magazines[] = {"2000Rnd_762x51_Belt_T_Red"};
+      class CopilotTurret: CopilotTurret {
         canEject = 1;
       };
-      class CopilotTurret: CopilotTurret {
+      class MainTurret: MainTurret {
+        magazines[] = {"2000Rnd_762x51_Belt_T_Red"};
         canEject = 1;
       };
       class RightDoorGun: RightDoorGun {


### PR DESCRIPTION
With my own mod that used all 3 turret positions in Ghosthawk, Copilot
and Left Gun were inversed because of the order their classes were put
down in config.cpp. This fixes it and adds compatibility with my mod and
hopefully others getting the same incompatibility problem.
(It is quite a retarded issue, I have to say.)
