### PR TITLE
Longer smoke grenades: 80 sec. Closed #436

### DIFF
--- a/AGM_Grenades/config.cpp
+++ b/AGM_Grenades/config.cpp
@@ -47,3 +47,10 @@ class AGM_Core_Default_Keys {
     alt = 1;
   };
 };
+
+class CfgAmmo {
+  class GrenadeHand;
+  class SmokeShell : GrenadeHand {
+    timeToLive = 80;
+  };
+};


### PR DESCRIPTION
Implemented in AGM_Grenades. Closes #436
