### PR TITLE
Update AGM_Explosives part II

### DIFF
--- a/AGM_Explosives/functions/fn_HandleScrollWheel.sqf
+++ b/AGM_Explosives/functions/fn_HandleScrollWheel.sqf
@@ -20,5 +20,6 @@ private ["_obj"];
 if (isNull(AGM_Explosives_Setup) || {!AGM_Explosives_ShiftDown}) exitWith {false};
 
 AGM_Explosives_Setup setDir ((getDir AGM_Explosives_Setup) + (_this*5));
+AGM_Explosives_TweakedAngle = AGM_Explosives_TweakedAngle + _this*5;
 
 true


### PR DESCRIPTION
So. The explosives will turn with player by default, enabling fast deploying a mine maze of 15 claymores.
If you hold Shift key and turn, the explosives won't turn with player, but keep their own directions.
Damn hard to describe in words, get part I and part II and try it out in game!
