### PR TITLE
Update AGM_Explosives part I

### DIFF
--- a/AGM_Explosives/functions/fn_SetupExplosive.sqf
+++ b/AGM_Explosives/functions/fn_SetupExplosive.sqf
@@ -42,9 +42,14 @@ _this spawn {
 		AGM_Explosives_Setup setVariable ["AGM_Timer", _timer];
 	};
 
+	AGM_Explosives_TweakedAngle = 0;
 	["AGM_Explosives_Placement","OnEachFrame", {
 		AGM_Explosives_pfeh_running = true;
 		AGM_Explosives_Setup setPos (positionCameraToWorld [0,0,1]);
+		if(!AGM_Explosives_Shiftdown) then
+			{
+			AGM_Explosives_Setup setDir (AGM_Explosives_TweakedAngle + getDir player);
+			};
 	}] call BIS_fnc_addStackedEventHandler;
 };
 true


### PR DESCRIPTION
So. The explosives will turn with player by default, enabling fast deploying a mine maze of 15 claymores.
If you hold Shift key and turn, the explosives won't turn with player, but keep their own directions.
Damn hard to describe in words, get part I and part II and try it out in game!
