### PR TITLE
stringtables -> tab to space & AGMod to AGM

### DIFF
--- a/AGM_Drag/stringtable.xml
+++ b/AGM_Drag/stringtable.xml
@@ -1,76 +1,76 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ID="Arma3">
-	<Package ID="AGM">
-		<Container ID="AGM_Drag">
-			<Key ID="STR_AGM_Drag_StartDrag">
-				<Original>
-					Drag
-				</Original>
-				<Russian>
-					Тащить
-				</Russian>
-				<Spanish>
-					Arrastrar
-				</Spanish>
-				<Polish>
-					Ciągnij	
-				</Polish>
-				<Czech>
-					Táhnout
-				</Czech>
-				<French>
-					Tirer
-				</French>
-				<German>
-					Ziehen
-				</German>
-			</Key>
-			<Key ID="STR_AGM_Drag_EndDrag">
-				<Original>
-					Release
-				</Original>
-				<Russian>
-					Отпустить
-				</Russian>
-				<Spanish>
-					Soltar
-				</Spanish>
-				<Polish>
-					Puść
-				</Polish>
-				<Czech>
-					Pustit
-				</Czech>
-				<French>
-					Lacher
-				</French>
-				<German>
-					Loslassen
-				</German>
-			</Key>
-			<Key ID="STR_AGM_Drag_UnableToDrag">
-				<Original>
-					Unable to drag item due to weight
-				</Original>
-				<Russian>
-					Слишком тяжелый предмет
-				</Russian>
-				<Spanish>
-					No se puede arrastrar el objeto debido a su peso
-				</Spanish>
-				<Polish>
-					Nie można ciągnąć tego przedmiotu z powodu jego wagi
-				</Polish>
-				<Czech>
-					Nelze táhnout z důvodu přílišné váhy
-				</Czech>
-				<French>
-					Impossible de tirer cet objet à cause de son poid
-				</French>
-				<German>
-					Dieser Gegenstand kann nicht gezogen werden, da er zu schwer ist.
-				</German>
-			</Key>
-		</Container>
-	</Package>
+    <Package ID="AGM">
+        <Container ID="AGM_Drag">
+            <Key ID="STR_AGM_Drag_StartDrag">
+                <English>
+                    Drag
+                </English>
+                <Russian>
+                    Тащить
+                </Russian>
+                <Spanish>
+                    Arrastrar
+                </Spanish>
+                <Polish>
+                    Ciągnij 
+                </Polish>
+                <Czech>
+                    Táhnout
+                </Czech>
+                <French>
+                    Tirer
+                </French>
+                <German>
+                    Ziehen
+                </German>
+            </Key>
+            <Key ID="STR_AGM_Drag_EndDrag">
+                <English>
+                    Release
+                </English>
+                <Russian>
+                    Отпустить
+                </Russian>
+                <Spanish>
+                    Soltar
+                </Spanish>
+                <Polish>
+                    Puść
+                </Polish>
+                <Czech>
+                    Pustit
+                </Czech>
+                <French>
+                    Lacher
+                </French>
+                <German>
+                    Loslassen
+                </German>
+            </Key>
+            <Key ID="STR_AGM_Drag_UnableToDrag">
+                <English>
+                    Unable to drag item due to weight
+                </English>
+                <Russian>
+                    Слишком тяжелый предмет
+                </Russian>
+                <Spanish>
+                    No se puede arrastrar el objeto debido a su peso
+                </Spanish>
+                <Polish>
+                    Nie można ciągnąć tego przedmiotu z powodu jego wagi
+                </Polish>
+                <Czech>
+                    Nelze táhnout z důvodu přílišné váhy
+                </Czech>
+                <French>
+                    Impossible de tirer cet objet à cause de son poid
+                </French>
+                <German>
+                    Dieser Gegenstand kann nicht gezogen werden, da er zu schwer ist.
+                </German>
+            </Key>
+        </Container>
+    </Package>
 </Project>

--- a/AGM_Explosives/stringtable.xml
+++ b/AGM_Explosives/stringtable.xml
@@ -1,157 +1,157 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ID="Arma3">
-	<Package ID="AGM">
-		<Container ID="AGM_Explosives">
-			<Key ID="STR_AGM_Explosives_Menu">
-				<English>Explosives >></English>
-				<German>Sprengstoffe >></German>
-				<Spanish>Explosivos >></Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Place">
-				<English>Place >></English>
-				<German>Platzieren >></German>
-				<Spanish>Colocar >></Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Detonate">
-				<English>Detonate >></English>
-				<German>Zünden >></German>
-				<Spanish>Detonar >></Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_DetonateCode">
-				<English>Explosive code: %1</English>
-				<German>Sprengstoffcode: %1</German>
-				<Spanish>Código del explosivo: %1</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_PlaceAction">
-				<English>&lt;t color=&apos;#00ff00&apos; &gt;Place&lt;/t&gt;</English>
-				<German>&lt;t color=&apos;#00ff00&apos; &gt;Platzieren&lt;/t&gt;</German>
-				<Spanish>&lt;t color=&apos;#00ff00&apos; &gt;Colocar&lt;/t&gt;</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_CancelAction">
-				<English>&lt;t color=&apos;#ff0000&apos; &gt;Cancel&lt;/t&gt;</English>
-				<German>&lt;t color=&apos;#ff0000&apos; &gt;Abbrechen&lt;/t&gt;</German>
-				<Spanish>&lt;t color=&apos;#ff0000&apos; &gt;Cancelar&lt;/t&gt;</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_AttachTo">
-				<English>&lt;t color=&apos;#008888&apos; &gt;Attach IED&lt;/t&gt;</English>
-				<German>&lt;t color=&apos;#008888&apos; &gt;USBV befestigen&lt;/t&gt;</German>
-				<Spanish>&lt;t color=&apos;#008888&apos; &gt;Enganchar IED&lt;/t&gt;</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Jammer_TurnOn">
-				<English>Turn On Thor III</English>
-				<German>Thor III aktivieren</German>
-				<Spanish>Encender Thor III</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Jammer_TurnOff">
-				<English>Turn Off Thor III</English>
-				<German>Thor III deaktivieren</German>
-				<Spanish>Apagar Thor III</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_cellphone_displayName">
-				<English>Cellphone</English>
-				<German>Mobiltelefon</German>
-				<Spanish>Télefono móvil</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_cellphone_description">
-				<English>Used to remotely trigger explosives</English>
-				<German>Wird benutzt um Sprengstoffe fernzuzünden</German>
-				<Spanish>Usado para detonar remotamente explosivos</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_clacker_displayName">
-				<English>M57 Firing Device</English>
-				<German>M57 Zündvorrichtung</German>
-				<Spanish>Dispositivo de detonación M57</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_clacker_description">
-				<English>Used to remotely trigger explosives</English>
-				<German>Wird benutzt um Sprengstoffe fernzuzünden</German>
-				<Spanish>Usado para detonar remotamente explosivos</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_DefusalKit_displayName">
-				<English>Defusal Kit</English>
-				<German>Entschärfungskit</German>
-				<Spanish>Kit de desactivación</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_DefusalKit_description">
-				<English>Allows defusing of explosives</English>
-				<German>Erlaubt die Entschärfung von Sprengstoffen</German>
-				<Spanish>Permite desactivar explosivos</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Phone_AddToSpeedDial">
-				<English>Add to Speed Dial</English>
-				<German>Zur Schnellauswahl hinzufügen</German>
-				<Spanish>Agregar a marcado rápido</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Clear">
-				<English>Clear</English>
-				<German>Löschen</German>
-				<Spanish>Despejar</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Phone_Dial">
-				<English>Dial</English>
-				<German>Wählen</German>
-				<Spanish>Marcar</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Phone_Up">
-				<English>Up</English>
-				<German>Hoch</German>
-				<Spanish>Arriba</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Phone_Down">
-				<English>Down</English>
-				<German>Runter</German>
-				<Spanish>Abajo</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Cancel">
-				<English>Cancel</English>
-				<German>Abbrechen</German>
-				<Spanish>Cancelar</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_DetonateMenu">
-				<English>Detonate Menu</English>
-				<German>"Zünden"-Menu</German>
-				<Spanish>Menú Detonar</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_PlaceMenu">
-				<English>Place Menu</English>
-				<German>"Platzieren"-Menu</German>
-				<Spanish>Menú Colocar</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_Defuse">
-				<English>Defuse</English>
-				<German>Entschärfen</German>
-				<Spanish>Desactivar</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_DefusingExplosive">
-				<English>Defusing Explosive...</English>
-				<German>Entschärfe Sprengstoff...</German>
-				<Spanish>Desactivando Explosivo...</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_timerName">
-				<English>Timer</English>
-				<German>Zeitzünder</German>
-				<Spanish>Temporizador</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_TimerMenu">
-				<English>Time: %1m %2s</English>
-				<German>Zeit: %1m %2s</German>
-				<Spanish>Tiempo: %1m %2s</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_SetTime">
-				<English>Set Time</English>
-				<German>Zeit einstellen</German>
-				<Spanish>Configurar Tiempo</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_TriggerMenu">
-				<English>Select a Trigger</English>
-				<German>Wähle einen Zünder</German>
-				<Spanish>Seleccionar un Disparador</Spanish>
-			</Key>
-			<Key ID="STR_AGM_Explosives_SelectTrigger">
-				<English>Select</English>
-				<German>Wählen</German>
-				<Spanish>Seleccionar</Spanish>
-			</Key>
-		</Container>
-	</Package>
+    <Package ID="AGM">
+        <Container ID="AGM_Explosives">
+            <Key ID="STR_AGM_Explosives_Menu">
+                <English>Explosives >></English>
+                <German>Sprengstoffe >></German>
+                <Spanish>Explosivos >></Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Place">
+                <English>Place >></English>
+                <German>Platzieren >></German>
+                <Spanish>Colocar >></Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Detonate">
+                <English>Detonate >></English>
+                <German>Zünden >></German>
+                <Spanish>Detonar >></Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_DetonateCode">
+                <English>Explosive code: %1</English>
+                <German>Sprengstoffcode: %1</German>
+                <Spanish>Código del explosivo: %1</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_PlaceAction">
+                <English>&lt;t color=&apos;#00ff00&apos; &gt;Place&lt;/t&gt;</English>
+                <German>&lt;t color=&apos;#00ff00&apos; &gt;Platzieren&lt;/t&gt;</German>
+                <Spanish>&lt;t color=&apos;#00ff00&apos; &gt;Colocar&lt;/t&gt;</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_CancelAction">
+                <English>&lt;t color=&apos;#ff0000&apos; &gt;Cancel&lt;/t&gt;</English>
+                <German>&lt;t color=&apos;#ff0000&apos; &gt;Abbrechen&lt;/t&gt;</German>
+                <Spanish>&lt;t color=&apos;#ff0000&apos; &gt;Cancelar&lt;/t&gt;</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_AttachTo">
+                <English>&lt;t color=&apos;#008888&apos; &gt;Attach IED&lt;/t&gt;</English>
+                <German>&lt;t color=&apos;#008888&apos; &gt;USBV befestigen&lt;/t&gt;</German>
+                <Spanish>&lt;t color=&apos;#008888&apos; &gt;Enganchar IED&lt;/t&gt;</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Jammer_TurnOn">
+                <English>Turn On Thor III</English>
+                <German>Thor III aktivieren</German>
+                <Spanish>Encender Thor III</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Jammer_TurnOff">
+                <English>Turn Off Thor III</English>
+                <German>Thor III deaktivieren</German>
+                <Spanish>Apagar Thor III</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_cellphone_displayName">
+                <English>Cellphone</English>
+                <German>Mobiltelefon</German>
+                <Spanish>Télefono móvil</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_cellphone_description">
+                <English>Used to remotely trigger explosives</English>
+                <German>Wird benutzt um Sprengstoffe fernzuzünden</German>
+                <Spanish>Usado para detonar remotamente explosivos</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_clacker_displayName">
+                <English>M57 Firing Device</English>
+                <German>M57 Zündvorrichtung</German>
+                <Spanish>Dispositivo de detonación M57</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_clacker_description">
+                <English>Used to remotely trigger explosives</English>
+                <German>Wird benutzt um Sprengstoffe fernzuzünden</German>
+                <Spanish>Usado para detonar remotamente explosivos</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_DefusalKit_displayName">
+                <English>Defusal Kit</English>
+                <German>Entschärfungskit</German>
+                <Spanish>Kit de desactivación</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_DefusalKit_description">
+                <English>Allows defusing of explosives</English>
+                <German>Erlaubt die Entschärfung von Sprengstoffen</German>
+                <Spanish>Permite desactivar explosivos</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Phone_AddToSpeedDial">
+                <English>Add to Speed Dial</English>
+                <German>Zur Schnellauswahl hinzufügen</German>
+                <Spanish>Agregar a marcado rápido</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Clear">
+                <English>Clear</English>
+                <German>Löschen</German>
+                <Spanish>Despejar</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Phone_Dial">
+                <English>Dial</English>
+                <German>Wählen</German>
+                <Spanish>Marcar</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Phone_Up">
+                <English>Up</English>
+                <German>Hoch</German>
+                <Spanish>Arriba</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Phone_Down">
+                <English>Down</English>
+                <German>Runter</German>
+                <Spanish>Abajo</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Cancel">
+                <English>Cancel</English>
+                <German>Abbrechen</German>
+                <Spanish>Cancelar</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_DetonateMenu">
+                <English>Detonate Menu</English>
+                <German>"Zünden"-Menu</German>
+                <Spanish>Menú Detonar</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_PlaceMenu">
+                <English>Place Menu</English>
+                <German>"Platzieren"-Menu</German>
+                <Spanish>Menú Colocar</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_Defuse">
+                <English>Defuse</English>
+                <German>Entschärfen</German>
+                <Spanish>Desactivar</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_DefusingExplosive">
+                <English>Defusing Explosive...</English>
+                <German>Entschärfe Sprengstoff...</German>
+                <Spanish>Desactivando Explosivo...</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_timerName">
+                <English>Timer</English>
+                <German>Zeitzünder</German>
+                <Spanish>Temporizador</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_TimerMenu">
+                <English>Time: %1m %2s</English>
+                <German>Zeit: %1m %2s</German>
+                <Spanish>Tiempo: %1m %2s</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_SetTime">
+                <English>Set Time</English>
+                <German>Zeit einstellen</German>
+                <Spanish>Configurar Tiempo</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_TriggerMenu">
+                <English>Select a Trigger</English>
+                <German>Wähle einen Zünder</German>
+                <Spanish>Seleccionar un Disparador</Spanish>
+            </Key>
+            <Key ID="STR_AGM_Explosives_SelectTrigger">
+                <English>Select</English>
+                <German>Wählen</German>
+                <Spanish>Seleccionar</Spanish>
+            </Key>
+        </Container>
+    </Package>
 </Project>

--- a/AGM_Grenades/stringtable.xml
+++ b/AGM_Grenades/stringtable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Project name="AGMod">
+<Project name="AGM">
   <Package name="Grenades">
 
     <Key ID="STR_AGM_Grenades_SwitchGrenadeMode">

--- a/AGM_Overheating/stringtable.xml
+++ b/AGM_Overheating/stringtable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Project name="AGMod">
+<Project name="AGM">
   <Package name="Overheating">
 
     <Key ID="STR_AGM_Overheating_SpareBarrelName">

--- a/AGM_Reload/stringtable.xml
+++ b/AGM_Reload/stringtable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<Project name="AGMod">
+<Project name="AGM">
   <Package name="Reload">
 
     <Key ID="STR_AGM_Reload_checkAmmo">

--- a/AGM_Repair/stringtable.xml
+++ b/AGM_Repair/stringtable.xml
@@ -21,79 +21,79 @@
         <Spanish>Todo está correcto!</Spanish>
         <French>Tout est OK!</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L1Wheel_check">
+    <Key ID="STR_AGM_Repair_L1Wheel_check">
         <English>L1 Wheel is damaged</English>
         <German>Reifen L1 ist beschädigt</German>
         <Spanish>Rueda I1 está dañada</Spanish>
         <French>Roue G1 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R1Wheel_check">
+    <Key ID="STR_AGM_Repair_R1Wheel_check">
         <English>R1 Wheel is damaged</English>
         <German>Reifen R1 ist beschädigt</German>
         <Spanish>Rueda D1 está dañada</Spanish>
         <French>Roue D1 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L2Wheel_check">
+    <Key ID="STR_AGM_Repair_L2Wheel_check">
         <English>L2 Wheel is damaged</English>
         <German>Reifen L2 ist beschädigt</German>
         <Spanish>Rueda I2 está dañada</Spanish>
         <French>Roue G1 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R2Wheel_check">
+    <Key ID="STR_AGM_Repair_R2Wheel_check">
         <English>R2 Wheel is damaged</English>
         <German>Reifen R2 ist beschädigt</German>
         <Spanish>Rueda D2 está dañada</Spanish>
         <French>Roue D2 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L3Wheel_check">
+    <Key ID="STR_AGM_Repair_L3Wheel_check">
         <English>L3 Wheel is damaged</English>
         <German>Reifen L3 ist beschädigt</German>
         <Spanish>Rueda I3 está dañada</Spanish>
         <French>Roue G3 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R3Wheel_check">
+    <Key ID="STR_AGM_Repair_R3Wheel_check">
         <English>R3 Wheel is damaged</English>
         <German>Reifen R3 ist beschädigt</German>
         <Spanish>Rueda D3 está dañada</Spanish>
         <French>Roue D3 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L4Wheel_check">
+    <Key ID="STR_AGM_Repair_L4Wheel_check">
         <English>L4 Wheel is damaged</English>
         <German>Reifen L4 ist beschädigt</German>
         <Spanish>Rueda I4 está dañada</Spanish>
         <French>Roue G4 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R4Wheel_check">
+    <Key ID="STR_AGM_Repair_R4Wheel_check">
         <English>R4 Wheel is damaged</English>
         <German>Reifen R4 ist beschädigt</German>
         <Spanish>Rueda D4 está dañada</Spanish>
         <French>Roue D4 endommagée</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Engine_check">
+    <Key ID="STR_AGM_Repair_Engine_check">
         <English>Engine is damaged</English>
         <German>Motor ist beschädigt</German>
         <Spanish>El motor esta dañado</Spanish>
         <French>Moteur endommagé</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Fuel_check">
+    <Key ID="STR_AGM_Repair_Fuel_check">
         <English>Fuel tank is damaged</English>
         <German>Tank ist beschädigt</German>
         <Spanish>El depósito está dañado</Spanish>
         <French>Réservoir endommagé</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Body_check">
+    <Key ID="STR_AGM_Repair_Body_check">
         <English>Karoserie is damaged</English>
         <German>Karoserie ist beschädigt</German>
         <Spanish>La carrocería está dañada</Spanish>
         <French>Carrosserie endommagé</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_LTrack_check">
+    <Key ID="STR_AGM_Repair_LTrack_check">
         <English>Left track is damaged</English>
         <German>Linke Kette ist beschädigt</German>
         <Spanish>La pista izquierda está dañada</Spanish>
         <French>Chenille gauche endommagée</French>
       </Key>
-  	<Key ID="STR_AGM_Repair_RTrack_check">
+    <Key ID="STR_AGM_Repair_RTrack_check">
         <English>Right track is damaged</English>
         <German>Rechte Kette ist beschädigt</German>
         <Spanish>La pista derecha está dañada</Spanish>
@@ -133,7 +133,7 @@
         <German>Heckrotor ist beschädigt</German>
         <French>Rotor anticouple endommagé</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Wheels">
+    <Key ID="STR_AGM_Repair_Wheels">
         <English>Wheels >></English>
         <German>Reifen >></German>
         <Spanish>Ruedas >></Spanish>
@@ -145,73 +145,73 @@
         <Spanish>Reparar rueda I1</Spanish>
         <French>Réparer la roue G1</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R1Wheel">
+    <Key ID="STR_AGM_Repair_R1Wheel">
         <English>Repair R1 Wheel</English>
         <German>Reifen R1 reparieren</German>
         <Spanish>Reparar rueda D1</Spanish>
         <French>Réparer la roue D1</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L2Wheel">
+    <Key ID="STR_AGM_Repair_L2Wheel">
         <English>Repair L2 Wheel</English>
         <German>Reifen L2 reparieren</German>
         <Spanish>Reparar rueda I2</Spanish>
         <French>Réparer la roue G2</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R2Wheel">
+    <Key ID="STR_AGM_Repair_R2Wheel">
         <English>Repair R2 Wheel</English>
         <German>Reifen R2 reparieren</German>
         <Spanish>Reparar rueda D2</Spanish>
         <French>Réparer la roue D2</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L3Wheel">
+    <Key ID="STR_AGM_Repair_L3Wheel">
         <English>Repair L3 Wheel</English>
         <German>Reifen L3 reparieren</German>
         <Spanish>Reparar rueda I3</Spanish>
         <French>Réparer la roue G3</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R3Wheel">
+    <Key ID="STR_AGM_Repair_R3Wheel">
         <English>Repair R3 Wheel</English>
         <German>Reifen R3 reparieren</German>
         <Spanish>Reparar rueda D3</Spanish>
         <French>Réparer la roue D3</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_L4Wheel">
+    <Key ID="STR_AGM_Repair_L4Wheel">
         <English>Repair L4 Wheel</English>
         <German>Reifen L4 reparieren</German>
         <Spanish>Reparar rueda I4</Spanish>
         <French>Réparer la roue G4</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_R4Wheel">
+    <Key ID="STR_AGM_Repair_R4Wheel">
         <English>Repair R4 Wheel</English>
         <German>Reifen R4 reparieren</German>
         <Spanish>Reparar rueda D4</Spanish>
         <French>Réparer la roue D4</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Engine">
+    <Key ID="STR_AGM_Repair_Engine">
         <English>Repair Engine</English>
         <German>Motor reparieren</German>
         <Spanish>Reparar motor</Spanish>
         <French>Réparer le moteur</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Fuel">
+    <Key ID="STR_AGM_Repair_Fuel">
         <English>Repair Fuel tank</English>
         <German>Tank reparieren</German>
         <Spanish>Reparar depósito</Spanish>
         <French>Réparer le réservoir</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Body">
+    <Key ID="STR_AGM_Repair_Body">
         <English>Repair Karoserie</English>
         <German>Karoserie reparieren</German>
         <Spanish>Reparar carrocería</Spanish>
         <French>Réparer la carrosserie</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_HitLTrack">
+    <Key ID="STR_AGM_Repair_HitLTrack">
         <English>Repair left track</English>
         <German>Linke Kette reparieren</German>
         <Spanish>Reparar pista izquierda</Spanish>
         <French>Réparer la chenille gauche</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_HitRTrack">
+    <Key ID="STR_AGM_Repair_HitRTrack">
         <English>Repair right track</English>
         <German>Rechte Kette reparieren</German>
         <Spanish>Reparar pista derecha</Spanish>
@@ -263,29 +263,29 @@
         <Spanish>No hay ninguna rueda!</Spanish>
         <French>Il n'y a pas de roues!</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_Repairing">
+    <Key ID="STR_AGM_Repair_Repairing">
         <English>Repairing...</English>
         <German>Reparieren...</German>
         <Spanish>Reparando...</Spanish>
         <French>Réparation...</French>
     </Key>
-  	<Key ID="STR_AGM_Repair_checkVehicle">
+    <Key ID="STR_AGM_Repair_checkVehicle">
         <English>Check Vehicle</English>
         <German>Fahrzeug überprüfen</German>
         <Spanish>Comprobando vehículo</Spanish>
         <French>Vérifier le véhicule</French>
     </Key>
-  	<Key ID="STR_AGM_Drag_StartDrag">
-  	  <Original>Drag</Original>
-  	  <Russian>Тащить</Russian>
-  	  <Spanish>Arrastrar</Spanish>
-  	  <French>Tirer</French>
-  	</Key>
-  	<Key ID="STR_AGM_Drag_EndDrag">
-  	  <Original>Release</Original>
-  	  <Russian>Отпустить</Russian>
-  	  <Spanish>Soltar</Spanish>
-  	  <French>Relacher</French>
-  	</Key>
+    <Key ID="STR_AGM_Drag_StartDrag">
+      <Original>Drag</Original>
+      <Russian>Тащить</Russian>
+      <Spanish>Arrastrar</Spanish>
+      <French>Tirer</French>
+    </Key>
+    <Key ID="STR_AGM_Drag_EndDrag">
+      <Original>Release</Original>
+      <Russian>Отпустить</Russian>
+      <Spanish>Soltar</Spanish>
+      <French>Relacher</French>
+    </Key>
   </Package>
 </Project>


### PR DESCRIPTION
fixed some stringtable.xml files. Indentations, tabs, `Original` instead of `English`, and some stray `AGMod` to the default `AGM`

Why do some stringtables look like this:

```
<Project ID="Arma3">
    <Package ID="AGM">
        <Container ID="AGM_Drag">
```

And others like this:

```
<Project name="AGM">
    <Package name="Grenades">
```
