### PR TITLE
Simplified GrenadeSelect. Fix #604 and restores Ctrl-G cycling. Close #489.

### DIFF
--- a/AGM_GrenadeSelect/clientInit.sqf
+++ b/AGM_GrenadeSelect/clientInit.sqf
@@ -22,5 +22,3 @@ _throwMuzzleNames = getArray (configfile >> "CfgWeapons" >> "Throw" >> "muzzles"
     AGM_MuzzlesFrags = AGM_MuzzlesFrags + [_muzzleName];
   };  
 } forEach _throwMuzzleNames;
-
-"" call AGM_GrenadeSelect_fnc_setNextGrenadeMuzzle;

--- a/AGM_GrenadeSelect/functions/fn_selectGrenadeFrag.sqf
+++ b/AGM_GrenadeSelect/functions/fn_selectGrenadeFrag.sqf
@@ -45,7 +45,6 @@ if (_numberOfMagazines > 0) then {
 } else {
   // There is a no muzzle with magazines --> select nothing
   AGM_CurrentMuzzleFrag = "";
-  AGM_CurrentMuzzleFrag call AGM_GrenadeSelect_fnc_setNextGrenadeMuzzle;
 
   _text = [localize "STR_AGM_GrenadeSelect_NoFragsLeft", [1,0,0]] call AGM_Core_fnc_stringToColoredText;
   [composeText [lineBreak, _text]] call AGM_Core_fnc_displayTextStructured;

--- a/AGM_GrenadeSelect/functions/fn_selectGrenadeOther.sqf
+++ b/AGM_GrenadeSelect/functions/fn_selectGrenadeOther.sqf
@@ -45,7 +45,6 @@ if (_numberOfMagazines > 0) then {
 } else {
   // There is a no muzzle with magazines --> select nothing
   AGM_CurrentMuzzleOther = "";
-  AGM_CurrentMuzzleOther call AGM_GrenadeSelect_fnc_setNextGrenadeMuzzle;
   
   _text = [localize "STR_AGM_GrenadeSelect_NoMiscGrenadeLeft", [1,0,0]] call AGM_Core_fnc_stringToColoredText;
   [composeText [lineBreak, _text]] call AGM_Core_fnc_displayTextStructured;

--- a/AGM_GrenadeSelect/functions/fn_setNextGrenadeMuzzle.sqf
+++ b/AGM_GrenadeSelect/functions/fn_setNextGrenadeMuzzle.sqf
@@ -78,27 +78,20 @@ _throwMuzzleNames = getArray (configfile >> "CfgWeapons" >> "Throw" >> "muzzles"
   };
 } forEach _backPackMagsToRemove;
 
-if (_muzzle != "") then {
-  // Fix the selector
-  if (player canAdd "HandGrenade_Stone") then {
-    // If there's space, add and remove an item
-    // We use HandGrenade_Stone to ensure we remove the same item we added a no other placed somewhere else
-    player addItem "HandGrenade_Stone"; player removeItem "HandGrenade_Stone";
-  } else {
-    // If there's no extra space, remove the current grenade and readd it.
-    // The correct grenade placement should be kept, as there's no place for the grenade to go except the correct one.
-    player removeItem _firstMagazine; player addItem _firstMagazine;
-  };
-};
-
 // Readd magazines
 {
-  uniformContainer player addItemCargo _x;
+  for [{_i=0},{_i < (_x select 1)}, {_i = _i + 1}] do {
+    player addItemToUniform (_x select 0); 
+  };
 } forEach _uniformMagsToRemove;
 {
-  vestContainer player addItemCargo _x;
+  for [{_i=0},{_i < (_x select 1)}, {_i = _i + 1}] do {
+    player addItemToVest (_x select 0); 
+  };
 } forEach _vestMagsToRemove;
 {
-  backpackContainer player addItemCargo _x;
+  for [{_i=0},{_i < (_x select 1)}, {_i = _i + 1}] do {
+    player addItemToBackpack (_x select 0); 
+  };
 } forEach _backPackMagsToRemove;
 


### PR DESCRIPTION
I'm dialing GrenadeSelect complexity down so we can all get behind a simpler, non-issue, AGM_GrenadeSelect. Hopefully this closes #489, maybe allowing to integrate GrenadeSelect on WeaponSelect.

In this version, the vanilla cycling is never broken, so you can always Ctrl-G. This is done by using the addItemToUniform, Vest, Backpack to add back removed grenades, commands which I previously overlooked. 

Arma picks a default grenade on respawn, so #604 is also fixed.

Lost is the ability to prevent auto-cycling when the player runs out of the current grenade type, but I'm thinking on optionally checking for that with an onFire event in the future.
