### PR TITLE
AGM_Interaction: Removed duplicate entries from CfgVehicles

### DIFF
--- a/AGM_Interaction/config.cpp
+++ b/AGM_Interaction/config.cpp
@@ -573,6 +573,7 @@ class CfgVehicles {
         priority = 1.2;
       };
     };
+    class AGM_SelfActions {};
   };
 
   /*


### PR DESCRIPTION
Some empty forward declarations are no longer necesary after adding handling actual actions for Loading/Unloading captives
