### PR TITLE
French language corrections and additions.

### DIFF
--- a/AGM_FireControlSystem/stringtable.xml
+++ b/AGM_FireControlSystem/stringtable.xml
@@ -8,7 +8,7 @@
       <Spanish>Iluminar Objetivo</Spanish>
       <Polish>Naświetl Cel</Polish>
       <Czech>Označit cíl</Czech>
-      <French>Cible Laser</French>
+      <French>Illuminer la cible</French>
       <Russian>Установить зероинг</Russian>
       <Hungarian>Cél jelölése</Hungarian>
     </Key>
@@ -18,7 +18,7 @@
       <Spanish>Fijado a</Spanish>
       <Polish>Wyzerowany na</Polish>
       <Czech>Nastaveno na</Czech>
-      <French>Mettre à zéro sur</French>
+      <French>Zéroté à</French>
       <Russian>Зероинг</Russian>
       <Hungarian>Zérózás</Hungarian>
     </Key>
@@ -28,6 +28,7 @@
       <Polish>Zwiększ zasięg FCS</Polish>
       <Spanish>Ajustar FCS (arriba)</Spanish>
       <Czech>Nastavit FCS Náměr (nahoru)</Czech>
+      <French>Augmenter la distance du SCT</French>
     </Key>
     <Key ID="STR_AGM_FireControlSystem_AdjustRangeDown">
       <English>Adjust FCS Range (Down)</English>
@@ -35,12 +36,13 @@
       <Polish>Zmniejsz zasięg FCS</Polish>
       <Spanish>Ajustar FCS(abajo)</Spanish>
       <Czech>Nastavit FCS Náměr (dolů)</Czech>
+      <French>Réduire la distance du SCT</French>
     </Key>
     <Key ID="STR_AGM_FireControlSystem_ResetFCS">
       <English>Reset FCS</English>
       <German>FLS zurücksetzen</German>
       <Spanish>Reiniciar FCS</Spanish>
-      <French>Redémarrer FCS</French>
+      <French>Réinitialiser le SCT</French>
       <Polish>Resetuj FCS</Polish>
       <Czech>Resetovat FCS</Czech>
     </Key>
@@ -48,7 +50,7 @@
       <English>FCS has been reset.</English>
       <German>FLS wurde zurückgesetzt.</German>
       <Spanish>FCS reiniciado</Spanish>
-      <French>FCS à été redémarré</French>
+      <French>SCT réinitialisé.</French>
       <Polish>FCS został zresetowany.</Polish>
       <Czech>FCS byl resetován.</Czech>
     </Key>


### PR DESCRIPTION
Corrected french entries in grammar, spelling and accuracy.
Added those missing.
Several accents in it.
SCT (système de conduite de tir) is the correct translation for FCS (Fire Control System).
