### PR TITLE
French language corrections and additions.

### DIFF
--- a/AGM_Logistics/stringtable.xml
+++ b/AGM_Logistics/stringtable.xml
@@ -13,7 +13,7 @@
     <Key ID="STR_AGM_Logistics_LoadItem">
       <English>Load Item</English>
       <Spanish>Cargar objeto</Spanish>
-      <French>Charger objet</French>
+      <French>Charger Objet</French>
       <Polish>Załaduj obiekt</Polish>
       <German>Gegenstand laden</German>
       <Czech>Naložit Předmět</Czech>
@@ -21,6 +21,7 @@
     <Key ID="STR_AGM_Logistics_LoadingItem">
       <English>Loading ...</English>
       <Spanish>Cargando ...</Spanish>
+      <French>Chargement...</French>
       <German>Verladen ...</German>
       <Polish>Ładowanie ...</Polish>
       <Czech>Naložuji ...</Czech>
@@ -28,6 +29,7 @@
     <Key ID="STR_AGM_Logistics_LoadedItem">
       <English>%1 loaded into %2</English>
       <Spanish>%1 cargado en %2</Spanish>
+      <French>%1 chargé dans %2</French>
       <German>%1 in %2 verladen</German>
       <Polish>%1 załadowano do %2</Polish>
       <Czech>%1 naloženo do %2</Czech>
@@ -80,7 +82,7 @@
       <Spanish>Arrastrar</Spanish>
       <Polish>Ciągnij</Polish>
       <Czech>Táhnout</Czech>
-      <French>Tirer</French>
+      <French>Tracter</French>
       <German>Ziehen</German>
     </Key>
     <Key ID="STR_AGM_Drag_EndDrag">
@@ -89,7 +91,7 @@
       <Spanish>Soltar</Spanish>
       <Polish>Puść</Polish>
       <Czech>Položit</Czech>
-      <French>Lacher</French>
+      <French>Lâcher</French>
       <German>Loslassen</German>
     </Key>
     <Key ID="STR_AGM_Drag_UnableToDrag">
@@ -98,7 +100,7 @@
       <Spanish>No se puede arrastrar el objeto debido a su peso</Spanish>
       <Polish>Nie można ciągnąć tego przedmiotu z powodu jego wagi</Polish>
       <Czech>Nelze táhnout z důvodu přílišné váhy</Czech>
-      <French>Impossible de tirer cet objet à cause de son poid</French>
+      <French>Trop lourd pour être tracté</French>
       <German>Dieser Gegenstand kann nicht gezogen werden, da er zu schwer ist.</German>
     </Key>
     <Key ID="STR_AGM_Drag_StartCarry">
@@ -115,7 +117,7 @@
       <Spanish>Soltar</Spanish>
       <Polish>Puść</Polish>
       <Czech>Položit</Czech>
-      <French>Lacher</French>
+      <French>Lâcher</French>
       <German>Loslassen</German>
     </Key>
   </Package>
@@ -124,7 +126,7 @@
       <English>Get in</English>
       <German>Einsteigen</German>
       <Spanish>Entrar en</Spanish>
-      <French>Entrer</French>
+      <French>Servir</French>
       <Polish>Wejdź</Polish>
       <Czech>Nastoupit</Czech>
     </Key>
@@ -132,7 +134,7 @@
       <English>Rotate weapon (CW)</English>
       <German>Waffe drehen (rechts)</German>
       <Spanish>Girar arma (SH)</Spanish>
-      <French>Tourner l'arme (CW)</French>
+      <French>Orienter l'arme (SH)</French>
       <Polish>Obróć broń (w prawo)</Polish>
       <Czech>Otočit zbraň (vpravo)</Czech>
     </Key>
@@ -140,7 +142,7 @@
       <English>Rotate weapon (CCW)</English>
       <German>Waffe drehen (links)</German>
       <Spanish>Girar arma (SAH)</Spanish>
-      <French>Tourner l'arme (CCW)</French>
+      <French>Orienter l'arme (SAH)</French>
       <Polish>Obróć broń (w lewo)</Polish>
       <Czech>Otočit zbraň (vlevo)</Czech>
     </Key>
@@ -158,7 +160,7 @@
       <English>Spare Track</English>
       <German>Ersatzkette</German>
       <Spanish>Cadena de repuesto</Spanish>
-      <French>Chenille de secours</French>
+      <French>Chenille de réserve</French>
       <Polish>Zapasowa gąsienica</Polish>
       <Czech>Náhradní pásy</Czech>
 
@@ -167,7 +169,7 @@
       <English>Spare Wheel</English>
       <German>Ersatzreifen</German>
       <Spanish>Rueda de repuesto</Spanish>
-      <French>roue de secours</French>
+      <French>Roue de secours</French>
       <Polish>Zapasowe koło</Polish>
       <Czech>Náhradní Kolo</Czech>
     </Key>
@@ -183,7 +185,7 @@
       <English>Vehicle is undamaged</English>
       <German>Fahrzeug ist unbeschädigt</German>
       <Spanish>Vehículo sin daños</Spanish>
-      <French>Le véhicule n'est pas endommager</French>
+      <French>Le véhicule n'est pas endommagé</French>
       <Polish>Pojazd jest nienaruszony</Polish>
       <Czech>Vozidlo není poškozené</Czech>
     </Key>
@@ -191,7 +193,7 @@
       <English>%1 is damaged</English>
       <German>%1 ist beschädigt</German>
       <Spanish>%1 dañado</Spanish>
-      <French>%1 est endommager</French>
+      <French>%1 est endommagé</French>
       <Polish>%1 jest uszkodzony</Polish>
       <Czech>%1 je poškozený</Czech>
     </Key>
@@ -199,7 +201,7 @@
       <English>%1 is heavily damaged</English>
       <German>%1 ist schwer beschädigt</German>
       <Spanish>%1 dañado severamente</Spanish>
-      <French>%1 est lourdement endommager</French>
+      <French>%1 est lourdement endommagé</French>
       <Polish>%1 jest mocno uszkodzony</Polish>
       <Czech>%1 je velice poškozené</Czech>
     </Key>
@@ -239,7 +241,7 @@
       <English>Body</English>
       <German>Karosserie</German>
       <Spanish>Carrocería</Spanish>
-      <French>carrosserie</French>
+      <French>Blindage</French>
       <Polish>Karoseria</Polish>
       <Czech>Karoserie</Czech>
     </Key>
@@ -247,7 +249,7 @@
       <English>Hull</English>
       <German>Wanne</German>
       <Spanish>Casco</Spanish>
-      <French>Hull</French>
+      <French>Caisse</French>
       <Polish>Kadłub</Polish>
       <Czech>Trup</Czech>
     </Key>
@@ -303,7 +305,7 @@
       <English>Left Front Wheel</English>
       <German>Linkes Vorderrad</German>
       <Spanish>Rueda frontal izquierda</Spanish>
-      <French>Roue avant gauche</French>
+      <French>Roue avant-gauche</French>
       <Polish>Przednie lewe koło</Polish>
       <Czech>Levé přední Kolo</Czech>
     </Key>
@@ -311,7 +313,7 @@
       <English>Right Front Wheel</English>
       <German>Rechtes Vorderrad</German>
       <Spanish>Rueda frontal derecha</Spanish>
-      <French>Roue avant droite</French>
+      <French>Roue avant-droite</French>
       <Polish>Przednie prawe koło</Polish>
       <Czech>Pravé přední Kolo</Czech>
     </Key>
@@ -319,7 +321,7 @@
       <English>Second Left Front Wheel</English>
       <German>Zweites linkes Vorderrad</German>
       <Spanish>Segunda rueda frontal izquierda</Spanish>
-      <French>Deuxième roue avant gauche</French>
+      <French>Deuxième roue avant-gauche</French>
       <Polish>Drugie przednie lewe koło</Polish>
       <Czech>Druhé Levé přední Kolo</Czech>
     </Key>
@@ -327,7 +329,7 @@
       <English>Second Right Front Wheel</English>
       <German>Zweites rechtes Vorderrad</German>
       <Spanish>Segunda rueda frontal derecha</Spanish>
-      <French>Deuxième roue avant droite</French>
+      <French>Deuxième roue avant-droite</French>
       <Polish>Drugie przednie prawe koło</Polish>
       <Czech>Druhé Pravé přední Kolo</Czech>
     </Key>
@@ -335,7 +337,7 @@
       <English>Left Middle Wheel</English>
       <German>Linkes mittleres Rad</German>
       <Spanish>Rueda central izquierda</Spanish>
-      <French>Roue millieu gauche</French>
+      <French>Roue milieu-gauche</French>
       <Polish>Środkowe lewe koło</Polish>
       <Czech>Levé prostřední Kolo</Czech>
     </Key>
@@ -343,7 +345,7 @@
       <English>Right Middle Wheel</English>
       <German>Rechtes mittleres Rad</German>
       <Spanish>Rueda central derecha</Spanish>
-      <French>Roue millieu droite</French>
+      <French>Roue milieu-droite</French>
       <Polish>Środkowe prawe koło</Polish>
       <Czech>Pravé prostřední Kolo</Czech>
     </Key>
@@ -351,7 +353,7 @@
       <English>Left Rear Wheel</English>
       <German>Linkes Hinterrad</German>
       <Spanish>Rueda trasera izquierda</Spanish>
-      <French>Roue arrière gauche</French>
+      <French>Roue arrière-gauche</French>
       <Polish>Tylnie lewe koło</Polish>
       <Czech>Levé zadní Kolo</Czech>
     </Key>
@@ -359,7 +361,7 @@
       <English>Right Rear Wheel</English>
       <German>Rechtes Hinterrad</German>
       <Spanish>Rueda trasera derecha</Spanish>
-      <French>Roue arrière droite</French>
+      <French>Roue arrière-droite</French>
       <Polish>Tylnie prawe koło</Polish>
       <Czech>Pravé zadní Kolo</Czech>
     </Key>
@@ -367,7 +369,7 @@
       <English>Avionics</English>
       <German>Avionik</German>
       <Spanish>Aviónica</Spanish>
-      <French>Instruments</French>
+      <French>Avionique</French>
       <Polish>Awionika</Polish>
       <Czech>Elektronika</Czech>
     </Key>
@@ -383,7 +385,7 @@
       <English>Tail Rotor</English>
       <German>Heckrotor</German>
       <Spanish>Rotor de cola</Spanish>
-      <French>rotor de queue</French>
+      <French>Rotor anticouple</French>
       <Polish>Tylni rotor</Polish>
       <Czech>Zadní Rotor</Czech>
     </Key>
@@ -391,7 +393,7 @@
       <English>Glass (right)</English>
       <German>Scheibe (rechts)</German>
       <Spanish>Ventana (derecha)</Spanish>
-      <French>Vitre (Droite)</French>
+      <French>Vitre (droite)</French>
       <Polish>Szyba (prawa)</Polish>
       <Czech>Sklo (pravé)</Czech>
     </Key>
@@ -399,7 +401,7 @@
       <English>Glass (left)</English>
       <German>Scheibe (links)</German>
       <Spanish>Ventana (izquierda)</Spanish>
-      <French>Vitre (Gauche)</French>
+      <French>Vitre (gauche)</French>
       <Polish>Szyba (lewa)</Polish>
       <Czech>Sklo (pravé)</Czech>
     </Key>
@@ -455,7 +457,7 @@
       <English>There's no track!</English>
       <German>Es ist keine Kette in der Nähe!</German>
       <Spanish>No hay cadena!</Spanish>
-      <French>Il n'y a pas de chenilles!</French>
+      <French>Il n'y a pas de chenille!</French>
       <Polish>Nie ma gąsienicy!</Polish>
       <Czech>Chybí pás!</Czech>
     </Key>
@@ -463,7 +465,7 @@
       <English>There's no wheel!</English>
       <German>Es ist kein Reifen in der Nähe!</German>
       <Spanish>No hay rueda!</Spanish>
-      <French>Il n'y a pas de roues!</French>
+      <French>Il n'y a pas de roue!</French>
       <Polish>Nie ma koła!</Polish>
       <Czech>Chybí kolo!</Czech>
     </Key>
@@ -471,7 +473,7 @@
       <English>Select Wheel Menu</English>
       <German>Reifenwahlmenü</German>
       <Spanish>Seleccionar menú de rueda</Spanish>
-      <French>Selectionner menu roues</French>
+      <French>Sélectionner Menu Roues</French>
       <Polish>Wybierz menu kół</Polish>
       <Czech>Zvolit Menu Kol</Czech>
     </Key>
@@ -479,7 +481,7 @@
       <English>Change Wheel</English>
       <German>Reifen wechseln</German>
       <Spanish>Cambiar rueda</Spanish>
-      <French>Changer roue</French>
+      <French>Changer Roue</French>
       <Polish>Wymień koło</Polish>
       <Czech>Vyměňit kolo</Czech>
     </Key>
@@ -487,7 +489,7 @@
       <English>Select Wheel Menu</English>
       <German>Reifenwahlmenü</German>
       <Spanish>Seleccionar menú de rueda</Spanish>
-      <French>Selectionner menu roues</French>
+      <French>Sélectionner Menu Roues</French>
       <Polish>Wybierz menu kół</Polish>
       <Czech>Zvolit Menu Kol</Czech>
     </Key>
@@ -495,6 +497,7 @@
       <English>Remove Wheel</English>
       <German>Reifen entf.</German>
       <Spanish>Quitar rueda</Spanish>
+      <French>Démonter Roue</French>
       <Polish>Zdejmij koło</Polish>
       <Czech>Odstranit Kolo</Czech>
     </Key>
@@ -510,7 +513,7 @@
       <English>Repaired %1</English>
       <German>%1 repariert</German>
       <Spanish>Reparado %1</Spanish>
-      <French>%1 Réparé</French>
+      <French>%1 réparé(e)</French>
       <Polish>Naprawiono %1</Polish>
       <Czech>Opraveno - %1</Czech>
     </Key>
@@ -518,6 +521,7 @@
       <English>Repair Wheel &gt;&gt;</English>
       <German>Reifen aufziehen &gt;&gt;</German>
       <Spanish>Reparar rueda</Spanish>
+      <French>Répare Roue &gt;&gt;</French>
       <Polish>Napraw koło &gt;&gt;</Polish>
       <Czech>Opravit Kolo &gt;&gt;</Czech>
     </Key>
@@ -525,6 +529,7 @@
       <English>Remove Wheel &gt;&gt;</English>
       <German>Reifen entfernen &gt;&gt;</German>
       <Spanish>Quitar rueda</Spanish>
+      <French>Démonte Roue &gt;&gt;</French>
       <Polish>Zdejmij koło &gt;&gt;</Polish>
       <Czech>Odstranit Kolo &gt;&gt;</Czech>
     </Key>
@@ -533,12 +538,14 @@
       <German>Entferne %1 ...</German>
       <Polish>Zdejmowanie %1 ...</Polish>
       <Spanish>Quitando %1 ...</Spanish>
+      <French>Démonte %1 ...</French>
       <Czech>Odstraňuji %1 ...</Czech>
     </Key>
     <Key ID="STR_AGM_Repair_RemovedWheel">
       <English>%1 removed</English>
       <German>%1 entfernt</German>
       <Spanish>%1 quitado</Spanish>
+      <French>%1 démontée</French>
       <Polish>%1 zdjęte</Polish>
       <Czech>%1 odstraněno</Czech>
     </Key>
@@ -564,7 +571,7 @@
       <English>Drone is full</English>
       <German>Drohne ist voll</German>
       <Spanish>El VANT está lleno</Spanish>
-      <French>Le drone est plein</French>
+      <French>L'UAV est chargé</French>
       <Polish>Dron jest naładowany</Polish>
       <Hungarian>Drón tele</Hungarian>
       <Czech>Dron je nabitý</Czech>
@@ -573,7 +580,7 @@
       <English>You need a UAV Battery</English>
       <German>Du brauchst eine UAV-Batterie</German>
       <Spanish>Necesitas una batería para VANT</Spanish>
-      <French>Vous avez besoin d'une Batterie-UAV</French>
+      <French>Pas de batterie UAV</French>
       <Polish>Potrzebujesz baterii UAV</Polish>
       <Hungarian>UAV-Akkumulátor szükséges</Hungarian>
       <Czech>Potřebuješ UAV-Baterii</Czech>
@@ -591,7 +598,7 @@
       <English>UAV Battery</English>
       <German>UAV-Batterie</German>
       <Spanish>Batería para VANT</Spanish>
-      <French>Batterie-UAV</French>
+      <French>Batterie UAV</French>
       <Polish>Bateria UAV</Polish>
       <Hungarian>UAV-Akkumulátor</Hungarian>
       <Czech>UAV-Baterie</Czech>
@@ -600,7 +607,7 @@
       <English>Used to refuel Carried UAV's</English>
       <German>Verwendet zum Aufladen von tragbaren UAV's</German>
       <Spanish>Usada para reabastecer el VANT</Spanish>
-      <French>Utiliser pour faire le plein de l'UAV</French>
+      <French>Utilisée pour recharger l'UAV</French>
       <Polish>Używana do naładowania UAV</Polish>
       <Hungarian>UAV újratöltéséhez</Hungarian>
       <Czech>Používané k dobíjení UAV</Czech>
@@ -630,7 +637,7 @@
       <Spanish>Cortando alambrado / cables ...</Spanish>
       <Polish>Przecinanie płotu / drutów ...</Polish>
       <Czech>Přestřihnout plot / dráty ...</Czech>
-      <French>Coupe la clôture / barbelée ...</French>
+      <French>Coupe la clôture / le barbelé ...</French>
     </Key>
     <Key ID="STR_AGM_CuttingFenceChat">
       <English>Cutting Fences!</English>
@@ -638,7 +645,7 @@
       <Spanish>Cortando alambrado!</Spanish>
       <Polish>Przecinanie płotu!</Polish>
       <Czech>Stříhání plotu!</Czech>
-      <French>Couper la clôture</French>
+      <French>Découpe de la clôture!</French>
     </Key>
     <Key ID="STR_AGM_FenceCut">
       <English>Fence cut</English>
@@ -655,6 +662,7 @@
       <German>Treibstoff prüfen</German>
       <Polish>Sprawdź poziom paliwa</Polish>
       <Spanish>Comprobar combustible</Spanish>
+      <French>Vérifier le carburant</French>
       <Czech>Zkontrolovat Palivo</Czech>
     </Key>
     <Key ID="STR_AGM_Resupply_CheckFuelCargo">
@@ -662,6 +670,7 @@
       <German>Treibstoffvorrat prüfen</German>
       <Polish>Sprawdź poziom paliwa (ładunek)</Polish>
       <Spanish>Comprobar combustible (en carga)</Spanish>
+      <French>Vérifier le carburant (Citerne)</French>
       <Czech>Zkontrolovat Palivo (náklad)</Czech>
     </Key>
     <Key ID="STR_AGM_Resupply_CheckFuelJerryCan">
@@ -669,6 +678,7 @@
       <German>Kanister prüfen</German>
       <Polish>Sprawdź kanister</Polish>
       <Spanish>Comprobar bidón</Spanish>
+      <French>Vérifier le jerrican</French>
       <Czech>Zkontrolovat Kanystr</Czech>
     </Key>
     <Key ID="STR_AGM_Resupply_CheckingFuel">
@@ -683,7 +693,7 @@
       <English>Checking Fuel (Cargo) ...</English>
       <German>Prüfe Treibstoffvorrat ...</German>
       <Spanish>Comprobando combustible en la carga...</Spanish>
-      <French>Vérification alimentation en carburant ...</French>
+      <French>Vérification carburant (Citerne) ...</French>
       <Polish>Sprawdzanie poziomu paliwa (ładunek) ...</Polish>
       <Czech>Kontroluji Palivo (náklad) ...</Czech>
     </Key>
@@ -707,7 +717,7 @@
       <English>Vehicle has %1 litre(s) left in Cargo</English>
       <German>Fahrzeug hat %1 Liter übrig im Vorrat</German>
       <Spanish>El vehículo tiene %1 litro(s) en la carga</Spanish>
-      <French>Le véhicule à %1 litre(s) en stock</French>
+      <French>Il reste %1 litre(s) dans la citerne</French>
       <Polish>W ładunku pojazdu zostało %1 litr(ów)</Polish>
       <Czech>Vozidlu zbývá %1 litr(ů) v nákladu</Czech>
     </Key>
@@ -715,7 +725,7 @@
       <English>Refuel Vehicle</English>
       <German>Fahrzeug betanken</German>
       <Spanish>Reabastecer vehículo</Spanish>
-      <French>Faire le plein du véhicule</French>
+      <French>Ravitailler le véhicule</French>
       <Polish>Zatankuj pojazd</Polish>
       <Czech>Natankovat Vozidlo</Czech>
     </Key>
@@ -723,7 +733,7 @@
       <English>Refuel Vehicle</English>
       <German>Fahrzeug betanken</German>
       <Spanish>Reabastecer vehículo</Spanish>
-      <French>Faire le plein du véhicule</French>
+      <French>Ravitailler la citerne</French>
       <Polish>Zatankuj pojazd</Polish>
       <Czech>Natankovat Vozidlo</Czech>
     </Key>
@@ -731,7 +741,7 @@
       <English>Drain Fuel</English>
       <German>Benzin ablassen</German>
       <Spanish>Drenar combustible</Spanish>
-      <French>Fuite de carburant</French>
+      <French>Vidanger le carburant</French>
       <Polish>Spuść paliwo</Polish>
       <Czech>Vypustit Palivo</Czech>
     </Key>
@@ -739,7 +749,7 @@
       <English>Drain Fuel Cargo</English>
       <German>Benzinvorrat ablassen</German>
       <Spanish>Drenar combustible en la carga</Spanish>
-      <French>Vidanger</French>
+      <French>Vidanger la citerne</French>
       <Polish>Spuść paliwo z ładunku</Polish>
       <Czech>Vypustit Palivo Nákladu</Czech>
     </Key>
@@ -763,7 +773,7 @@
       <English>Draining Fuel Cargo ...</English>
       <German>Benzinvorrat ablassen ...</German>
       <Spanish>Drenando combustible de la carga</Spanish>
-      <French>Vidange du carburant ...</French>
+      <French>Vidange de la citerne ...</French>
       <Polish>Spuszczanie paliwa z ładunku ...</Polish>
       <Czech>Vypouštění paliva nákladu ...</Czech>
     </Key>
@@ -779,7 +789,7 @@
       <English>Drained Fuel</English>
       <German>Benzin abgelassen</German>
       <Spanish>Combustible drenado</Spanish>
-      <French>Vidange du carburant effectué</French>
+      <French>Carburant vidangé</French>
       <Polish>Spuszczono paliwo</Polish>
       <Czech>Vypuštěné Palivo</Czech>
     </Key>
@@ -787,7 +797,7 @@
       <English>Drained Fuel Cargo</English>
       <German>Benzinvorrat abgelassen</German>
       <Spanish>Combustible en la carga drenado</Spanish>
-      <French>Vidange effectuer</French>
+      <French>Citerne vidangée</French>
       <Polish>Spuszczono paliwo z ładunku</Polish>
       <Czech>Vypuštěné Palivo Nákladu</Czech>
     </Key>
@@ -797,7 +807,7 @@
       <English>Airdrop Box</English>
       <German>Box abwerfen</German>
       <Spanish>Lanzar caja con paracaídas</Spanish>
-      <French>Parachutage de caisses</French>
+      <French>Largage de caisse</French>
       <Polish>Zrzut ładunku na spadochronie</Polish>
       <Czech>Schodnit letecky bednu</Czech>
     </Key>


### PR DESCRIPTION
Corrected french entries in grammar, spelling, consistency and accuracy.
Added those missing.
Several accents in it.

_Notes_
(SH), meaning Sens Horlogique, is the right translation for (CW) meaning ClockWise.
(SAH), meaning Sens Anti-Horlogique, is the right translation for (CCW) meaning CounterClockWise.
StaticWeapons: Servir since crew members are "servants".
Check http://www.defense.gouv.fr/terre/equipements/armement-individuel-et-collectif/mortier-81-mm-llr

IMHO, "Dienen" would fit better in German btw. Eg. "Der "Schütze 1" bediente das schwere Maschinengewehr"
