### PR TITLE
French language corrections.

### DIFF
--- a/AGM_Overheating/stringtable.xml
+++ b/AGM_Overheating/stringtable.xml
@@ -28,7 +28,7 @@
       <Spanish>Arma encasquillada!</Spanish>
       <Polish>Broń się zacięła!</Polish>
       <Czech>Zbraň se zasekla!</Czech>
-      <French>Arme enrayéé</French>
+      <French>Arme enrayée</French>
       <Russian>Оружие заклинило!</Russian>
       <Hungarian>Elakadt a fegyver!</Hungarian>
     </Key>
@@ -48,7 +48,7 @@
       <Spanish>Arma desencasquillada</Spanish>
       <Polish>Zacięcie usunięte</Polish>
       <Czech>Zbraň uvolněna</Czech>
-      <French>Désenrayé</French>
+      <French>Arme désenrayée</French>
       <Russian>Оружие исправлено</Russian>
       <Hungarian>Akadály elhárítva!</Hungarian>
     </Key>


### PR DESCRIPTION
Corrected french entries in spelling and accuracy.

Source for "deuxième canon":
http://www.defense.gouv.fr/content/download/118246/1148074/file/anf1.pdf

(Typo alert, made a couple of mistakes, not sure how to fix that)

<French>Arme enrayéé</French> -> <French>Arme enrayée</French>
<French>Désenrayé</French> - > <French>Arme désenrayée</French>
