### PR TITLE
French language corrections.

### DIFF
--- a/AGM_Hearing/stringtable.xml
+++ b/AGM_Hearing/stringtable.xml
@@ -9,7 +9,7 @@
       <Polish>Stopery do uszu</Polish>
       <Czech>Špunty</Czech>
       <Russian>Беруши</Russian>
-      <French>Bouchons d'oreilles</French>
+      <French>Bouchons Anti-Bruits</French>
       <Hungarian>Füldugó</Hungarian>
     </Key>
     <Key ID="STR_AGM_Hearing_Earbuds_Description">
@@ -19,7 +19,7 @@
       <Polish>Stopery do uszu umożliwiają użytkownikowi przebywać w pobliżu głośnej broni bez poniesienia konsekwencji jaką jest utrata słuchu.</Polish>
       <Czech>Ochranné špunty umožňují uživateli, aby neutrpěl zranění jeho sluchu v blízkosti hlasitých zbraní.</Czech>
       <Russian>Беруши позволяют избежать потери слуха при близкой громкой стрельбе.</Russian>
-      <French>Bouchons d'oreilles permettant à l'utilisateur de se trouver à proximité des armes sans endommager son audition.</French>
+      <French>Bouchons Anti-Bruits pour la prévention des traumatismes sonores aigus.</French>
       <Hungarian>Erősebb hanghatásoktól védő füldugó, megakadályozza a nagy hanggal járó fegyverzettől való halláskárosodást.</Hungarian>
     </Key>
     <Key ID="STR_AGM_Hearing_Earbuds_On">
@@ -39,7 +39,7 @@
       <Polish>Zdejmij stopery</Polish>
       <Czech>Špunty venku z uší</Czech>
       <Russian>Беруши сняты</Russian>
-      <French>Bouchons enlever</French>
+      <French>Bouchons enlevés</French>
       <Hungarian>Füldugó kivéve</Hungarian>
     </Key>
     <Key ID="STR_AGM_Hearing_NoBuds">
@@ -49,7 +49,7 @@
       <Polish>Nie masz stoperów</Polish>
       <Czech>Nemáš žádné špunty</Czech>
       <Russian>У вас нет беруш</Russian>
-      <French>Vous n'avez pas de bouchons d'oreilles</French>
+      <French>Vous n'avez pas de Bouchons Anti-Bruits</French>
       <Hungarian>Nincs füldugód</Hungarian>
     </Key>
     <Key ID="STR_AGM_Hearing_Inventory_Full">


### PR DESCRIPTION
Corrected french entries in grammar, spelling, accuracy.

Bouchons Anti-Bruits with capitals to match the "BAB" acronym, well known in french military circles.

Source:
http://www.ecole-valdegrace.sante.defense.gouv.fr/content/download/3505/53030/file/2-1_Casanova-_Prevention_des_traumatismes_sonores_aigus_a_l_unite.pdf
