### PR TITLE
Removed humidity effect on bullet trajectory. See #995

### DIFF
--- a/AGM_Wind/functions/fn_firedEH.sqf
+++ b/AGM_Wind/functions/fn_firedEH.sqf
@@ -17,9 +17,6 @@ _this spawn {
     _coefficient = 0.35;
   };
 
-  // HUMIDITY
-  _round setVelocity ([velocity _round, {_this - _this * humidity * 0.1}] call AGM_Core_fnc_map);
-
   // WIND
   _time = time;
   while {!isNull _round and alive _round} do {


### PR DESCRIPTION
Reasons:
- The effect is almost negligible. Its many times lower than both altitude and temperature (which are currently not considered); it's probably also lower than Coriolis and powder temperature (see #995).
- We currently have the effect reversed; although unintuitive, moist air is in fact lighter than dry air. Velocity should in any case be reduced when humidity is 0, not 100% (see #995).
- Our current implementation relies on Arma 3 humidity command, which behaves nothing like real humidity (not even close, see https://community.bistudio.com/wiki/humidity).

If anything, altitude and temperature (and optionally powder temp) should be the things to consider.
