### PR TITLE
Powder temperature effect

### DIFF
--- a/AGM_Wind/functions/fn_firedEH.sqf
+++ b/AGM_Wind/functions/fn_firedEH.sqf
@@ -15,7 +15,7 @@ _this spawn {
     _airFriction = 0.0007;
   };
 // powder temp effect
-_round setVelocity ((velocity _round) vectorMultiply (((AGM_Wind_currectTemperature + 273.13) / 288.13 - 1) / 2.5 + 1 ));
+_round setVelocity ((velocity _round) vectorMultiply (((AGM_Wind_currentTemperature + 273.13) / 288.13 - 1) / 2.5 + 1 ));
   // WIND
   _time = time;
   while {!isNull _round and alive _round} do {


### PR DESCRIPTION
NEEDS CHECKING BEFORE MERGING!

As it was discussed here #995. PT has large influence on initial speed of bullet.

initial speed for diffrent powder Temperatures:
Temp(K)//init vel //Temp_change vs velocity_change  
268//884,52//2,48
273//890,9//2,48
278//897,26//2,48
283//903,63//2,48
288//910//0
293//916,37//2,48
298//922,74//2,48
303//929,11//2,48
*http://ballistics.eu/exterior.html
*standard temperature set as 288.15 K based on International Standard Atmosphere

Acording to table above this influence is linear and looks like this:
_velocity_update = _velocity*(((AGM_Wind_currectTemperature+273.15)/288.15-1)/2.5+1 )
AGM_Wind_currectTemperature variable doesn't exist yet but was created here: #1039

Someone please check file I'm not  any good in scripting

edited:Ready to merge after #1039
