### PR TITLE
Work on #1386

### DIFF
--- a/AGM_GetIn/config.cpp
+++ b/AGM_GetIn/config.cpp
@@ -37,7 +37,12 @@ class CfgFunctions {
 };
 
 class CfgVehicles {
-  class LandVehicle;
+
+  class AllVehicles;
+  class LandVehicle : AllVehicles {
+    class AGM_Actions;
+    class AGM_SelfActions;
+  };
   /*class StaticWeapon: LandVehicle {
     class AGM_Actions {
       class AGM_GetIn {
@@ -66,7 +71,7 @@ class CfgVehicles {
   };*/
 
   class Car: LandVehicle {
-    class AGM_Actions {
+    class AGM_Actions : AGM_Actions {
       class AGM_GetInDriver {
         displayName = "$STR_AGM_GetInVehicleAsDriver";
         distance = 4;
@@ -113,7 +118,7 @@ class CfgVehicles {
         icon = "\A3\ui_f\data\igui\cfg\actions\getincargo_ca.paa";
       };
     };
-    class AGM_SelfActions {
+    class AGM_SelfActions : AGM_SelfActions {
       class AGM_MoveToDriver {
         displayName = "$STR_AGM_MoveToDriver";
         condition = "[_player, vehicle _player] call AGM_GetIn_fnc_canGetInDriver";
@@ -163,7 +168,7 @@ class CfgVehicles {
   };
 
   class Tank: LandVehicle {
-    class AGM_Actions {
+    class AGM_Actions : AGM_Actions {
       class AGM_GetInDriver {
         displayName = "$STR_AGM_GetInVehicleAsDriver";
         distance = 4;
@@ -210,7 +215,7 @@ class CfgVehicles {
         icon = "\A3\ui_f\data\igui\cfg\actions\getincargo_ca.paa";
       };
     };
-    class AGM_SelfActions {
+    class AGM_SelfActions : AGM_SelfActions {
       class AGM_MoveToDriver {
         displayName = "$STR_AGM_MoveToDriver";
         condition = "[_player, vehicle _player] call AGM_GetIn_fnc_canGetInDriver";
@@ -259,8 +264,7 @@ class CfgVehicles {
     };
   };
   
-  class Ship;
-  class Ship_F: Ship {
+  class Ship : AllVehicles {
     class AGM_Actions {
       class AGM_GetInDriver {
         displayName = "$STR_AGM_GetInVehicleAsDriver";
@@ -339,9 +343,12 @@ class CfgVehicles {
     };
   };
   
-  class Air;
+  class Air : AllVehicles {
+    class AGM_Actions;
+    class AGM_SelfActions;
+  };
   class Plane: Air {
-    class AGM_Actions {
+    class AGM_Actions : AGM_Actions {
       class AGM_GetInPilot {
         displayName = "$STR_AGM_GetInVehicleAsPilot";
         distance = 4;
@@ -370,7 +377,7 @@ class CfgVehicles {
         icon = "\A3\ui_f\data\igui\cfg\actions\getincargo_ca.paa";
       };
     };
-    class AGM_SelfActions {
+    class AGM_SelfActions : AGM_SelfActions {
       class AGM_MoveToPilot {
         displayName = "$STR_AGM_MoveToPilot";
         condition = "[_player, vehicle _player] call AGM_GetIn_fnc_canGetInPilot";
@@ -401,10 +408,8 @@ class CfgVehicles {
     };
   };
   
-  
-  class Helicopter;
-  class Helicopter_Base_F: Helicopter {
-    class AGM_Actions {
+  class Helicopter : Air {
+    class AGM_Actions : AGM_Actions {
       class AGM_GetInPilot {
         displayName = "$STR_AGM_GetInVehicleAsPilot";
         distance = 4;
@@ -442,7 +447,7 @@ class CfgVehicles {
         icon = "\A3\ui_f\data\igui\cfg\actions\getincargo_ca.paa";
       };
     };
-    class AGM_SelfActions {
+    class AGM_SelfActions : AGM_SelfActions {
       class AGM_MoveToPilot {
         displayName = "$STR_AGM_MoveToPilot";
         condition = "[_player, vehicle _player] call AGM_GetIn_fnc_canGetInPilot";

--- a/AGM_Logistics/config.cpp
+++ b/AGM_Logistics/config.cpp
@@ -502,16 +502,19 @@ class CfgVehicles {
     AGM_fuelCapacity = AGM_FUELCAPACITY_LEOPARD;
   };
 
-  class AllVehicles;
+  class AllVehicles {
+    class AGM_Actions;
+  };
   class Air: AllVehicles {
     AGM_Paradrop = 0;
+    class AGM_Actions: AGM_Actions {};
   };
 
   // Repair helicopters
   class Helicopter: Air {
     AGM_fuelCapacity = 240;  // in liter.
     AGM_Vehicle_Cargo = 8;
-    class AGM_Actions {
+    class AGM_Actions : AGM_Actions {
       MACRO_UNLOAD
       MACRO_REFUEL
       MACRO_RELOAD_MAGS
@@ -605,7 +608,7 @@ class CfgVehicles {
   class Plane: Air {
     AGM_fuelCapacity = 600;  // in liter.
     AGM_Vehicle_Cargo = 4;
-    class AGM_Actions {
+    class AGM_Actions : AGM_Actions {
       MACRO_UNLOAD
       MACRO_REFUEL
       MACRO_RELOAD_MAGS
@@ -673,7 +676,7 @@ class CfgVehicles {
     AGM_fuelCapacity = 40;  // in liter.
     AGM_Vehicle_Cargo = 4;
 
-    class AGM_Actions {
+    class AGM_Actions : AGM_Actions {
       MACRO_UNLOAD
       MACRO_REFUEL
       class AGM_Repair {


### PR DESCRIPTION
Work on #1386 for Logistics and GetIn. For some reason it gives me errors if I try to derive AGM_Actions inheritance from AllVehicles, so the I'm beginng from LandVehicles, Air and Ship.

Fixes repair, refuel and loading/unloading for helicopters and also paradropping.
