### PR TITLE
removed "explosive" from the module options displayName

### DIFF
--- a/AGM_Explosives/Module.hpp
+++ b/AGM_Explosives/Module.hpp
@@ -9,7 +9,7 @@ class AGM_ModuleExplosive: Module_F {
     icon = "\AGM_Explosives\UI\IconExplosives_ca.paa";
 	class Arguments {
 		class RequireSpecialist {
-			displayName = "Require explosive specialists?";
+			displayName = "Require specialists?";
 			//description = "Require explosive specialists to plant/disable explosives? Default: No";
 			// The above distinction is commented out due to the explanation in fn_SetupExplosive.sqf
 			description = "Require explosive specialists to disable explosives? Default: No";


### PR DESCRIPTION
it was displayed as "Require explosive" and the second module option is `"Punish non-specialists?";`.
So both now omit the "explosive" word.

Old:
![image](https://cloud.githubusercontent.com/assets/1235520/4963664/1236c6c4-6725-11e4-86f3-1b7ba664ec60.png)
