### PR TITLE
add possibility to toggle BFT Markers

### DIFF
--- a/AGM_Map/clientInit.sqf
+++ b/AGM_Map/clientInit.sqf
@@ -44,6 +44,13 @@ if (!hasInterface) exitWith{};
 
       sleep AGM_Map_BFT_Interval;
     };
+    
+    if(!AGM_Map_BFT_Enabled) then {
+      {
+        deleteMarkerLocal _x;
+      } forEach _markers;
+    };
+    
   };
 };
 


### PR DESCRIPTION
When negating `AGM_Map_BFT_Enabled` it's now possible to toggle the
markers accordingly ... while playing.
