### PR TITLE
Experiment on disarming

### DIFF
--- a/AGM_Interaction/config.cpp
+++ b/AGM_Interaction/config.cpp
@@ -24,6 +24,7 @@ class CfgFunctions {
       class canInteractWith;
       class canLockDoor;
       class canTapShoulder;
+      class disarm;
       class getActions2;
       class GetActions;
       class getDoor;
@@ -302,6 +303,15 @@ class CfgVehicles {
         statement = "[_target, '{_this addRating -rating _this}', _target] call AGM_Core_fnc_execRemoteFnc";
         showDisabled = 0;
         priority = 2.5;
+      };
+
+      class AGM_Disarm {
+        displayName = "$STR_AGM_Interaction_Disarm";
+        distance = 4;
+        condition = "_target getVariable ['AGM_isUnconscious' false] || _target getVariable ['AGM_isCaptive' false]";
+        statement = "[[_target, _player], AGM_Interacion_fnc_disarm, _target] call AGM_Core_fnc_execRemoteFnc";
+        showDisabled = 0;
+        priority = 1.5;
       };
     };
 

--- a/AGM_Interaction/functions/fn_disarm.sqf
+++ b/AGM_Interaction/functions/fn_disarm.sqf
@@ -1,0 +1,123 @@
+/*
+Author: CAA-Picard
+
+Description:
+Disarm the player
+
+Arguments:
+0: The local unit being disarmed
+1: The unit doing the disarming
+
+Return value:
+None
+*/
+
+private ["_unit", "_guard", "_allGear", "_wh"];
+
+_unit = _this select 0;
+_guard = _this select 1;
+
+_allGear = [
+  (headgear _unit),
+  (goggles _unit),
+  (uniform _unit),
+  (uniformItems _unit),
+  (vest _unit),
+  (vestItems _unit),
+  (backpack _unit),
+  (backpackItems _unit),
+  (primaryWeapon _unit),
+  (primaryWeaponItems _unit),
+  (primaryWeaponMagazine _unit),
+  (secondaryWeapon _unit),
+  (secondaryWeaponItems _unit),
+  (secondaryWeaponMagazine _unit),
+  (handgunWeapon _unit),
+  (handgunItems _unit),
+  (handgunMagazine _unit),
+  (assignedItems _unit),
+  (binocular _unit)
+];
+
+// Make the unit drop it's backpack
+_unit addBackpack "Bag_Base";
+ removeBackpack _unit;
+
+// Remove the uniform items
+removeUniform _unit;
+_unit forceAddUniform (_allGear select 2);
+
+// Remove the vest and all it's content
+removeVest _unit;
+
+// Remove the rest of the stuff
+removeAllWeapons _unit;
+removeAllAssignedItems _unit;
+
+
+_wh = createVehicle ["WeaponHolderSimulated", [0,0,0], [], 0, "CAN_COLLIDE"];
+
+// Store vest and vest items
+if (_allGear select 4 != "") then {
+  _wh addItemCargoGlobal [_allGear select 4,1];
+  {
+    _wh addItemCargoGlobal [_x,1];
+  }forEach (_allGear select 5);
+};
+
+// Store main weapon and accesories
+if (_allGear select 8 != "") then {
+  _wh addItemCargoGlobal [_allGear select 8,1];
+  {
+    if (_x != "") then {
+      _wh addItemCargoGlobal [_x,1];
+    };
+  }forEach (_allGear select 9);
+  {
+    if (_x != "") then {
+      _wh addItemCargoGlobal [_x,1];
+    };
+  }forEach (_allGear select 10);
+};
+
+// Store secondary weapon and accesories
+if (_allGear select 11 != "") then {
+  _wh addItemCargoGlobal [_allGear select 11,1];
+  {
+    if (_x != "") then {
+      _wh addItemCargoGlobal [_x,1];
+    };
+  }forEach (_allGear select 12);
+  {
+    if (_x != "") then {
+      _wh addItemCargoGlobal [_x,1];
+    };
+  }forEach (_allGear select 13);
+};
+
+// Store pistol and accesories
+if (_allGear select 14 != "") then {
+  _wh addItemCargoGlobal [_allGear select 14,1];
+  {
+    if (_x != "") then {
+      _wh addItemCargoGlobal [_x,1];
+    };
+  }forEach (_allGear select 15);
+  {
+    if (_x != "") then {
+      _wh addItemCargoGlobal [_x,1];
+    };
+  }forEach (_allGear select 16);
+};
+
+// Store uniform items
+{
+  _wh addItemCargoGlobal [_x,1];
+}forEach (_allGear select 3);
+
+// Store assigned items
+{
+  _wh addItemCargoGlobal [_x,1];
+}forEach (_allGear select 17);
+
+_wh setPos getPos _unit;

--- a/AGM_Interaction/stringtable.xml
+++ b/AGM_Interaction/stringtable.xml
@@ -390,6 +390,9 @@
       <Portuguese>Abaixe-se!</Portuguese>
       <Italian>A Terra!</Italian>
     </Key>
+    <Key ID="STR_AGM_Interaction_Disarm">
+      <English>Disarm</English>
+    </Key>
     <Key ID="STR_AGM_Interaction_TeamManagement">
       <English>Team Management &gt;&gt;</English>
       <German>Team Management &gt;&gt;</German>


### PR DESCRIPTION
**Do not merge**

This is not a real PR yet, but a way to see if there's any way to make this happen. 

Here's the problem: the weapon classes never change, even if you remove the attachments. So if you disarm a guy who left the weapon attachments at home you still get a fresh weapon with all the attachments defined in the config. Commands to add/remove attachment from weapons stored on cargo (e.g. weaponholder) doesn't seem to exist. Neither for making a unit drop his weapon.

The only alternative I could think of is looking up the class hierarchy of the weapon and try to spawn the same weapon without attachments, but that may not be very reliable. 

Any ideas??
