### PR TITLE
paradropped ammoboxes are marked with smoke when landed

### DIFF
--- a/AGM_Logistics/functions/ParaDrop/fn_paraDrop.sqf
+++ b/AGM_Logistics/functions/ParaDrop/fn_paraDrop.sqf
@@ -34,9 +34,9 @@ _this spawn {
   detach _parachute;
   _item attachTo [_parachute, [0, 0, -1]];
 
-  //_smoke = [] call _fnc_smoke;
   _light = [] call _fnc_light;
 
   waitUntil {sleep 0.1; position _item select 2 < 1};
   detach _item;
+  _smoke = [] call _fnc_smoke;
 };


### PR DESCRIPTION
commented code deleted
added: yellow smokegrenade is used on landed paradroped objects
assumption: code was commented because smoke in 500m height make not that much sense and smoke may not last until the item is at ground
