### PR TITLE
Estimate AGM_BulletMass for unknown ammo.

### DIFF
--- a/AGM_Overheating/functions/fn_overheat.sqf
+++ b/AGM_Overheating/functions/fn_overheat.sqf
@@ -17,7 +17,12 @@ _temperature = _overheat select 0;
 _time = _overheat select 1;
 
 // Get physical parameters
-_energyIncrement = 0.75 * 0.0005 * getNumber (configFile >> "CfgAmmo" >> _ammo >> "AGM_BulletMass") * (vectorMagnitudeSqr _velocity);
+_bulletMass = getNumber (configFile >> "CfgAmmo" >> _ammo >> "AGM_BulletMass");
+if (_bulletMass == 0) then {
+  // If the bullet mass is not configured, estimate it
+  _bulletMass = 3.4334 + 0.5171 * (getNumber (configFile >> "CfgAmmo" >> _ammo >> "hit") + getNumber (configFile >> "CfgAmmo" >> _ammo >> "caliber"));
+};
+_energyIncrement = 0.75 * 0.0005 * _bulletMass * (vectorMagnitudeSqr _velocity);
 _barrelMass = 0.50 * (getNumber (configFile >> "CfgWeapons" >> _weapon >> "WeaponSlotsInfo" >> "mass") / 22.0) max 1.0;
 
 // Calculate cooling


### PR DESCRIPTION
For addons, which don't have the bullet mass correctly configured, I found out a pretty reliable way of estimating it from the hit and caliber values. This should get overheating working more or less realistically for all unsupported mods out there.

![image](https://cloud.githubusercontent.com/assets/7674951/5329209/f96ade9c-7d80-11e4-8a1c-e184485727d7.png)
