### PR TITLE
RU translation for "AGM Team"

### DIFF
--- a/AGM_Core/stringtable.xml
+++ b/AGM_Core/stringtable.xml
@@ -6,9 +6,10 @@
       <English>AGM-Team</English>
       <German>AGM-Team</German>
       <Spanish>AGM-Team</Spanish>
-      <Czech>AGM-Team</Czech>
       <Polish>AGM-Team</Polish>
+      <Czech>AGM-Team</Czech>
       <French>AGM-Team</French>
+      <Russian>Команда AGM</Russian>
       <Portuguese>AGM-Team</Portuguese>
       <Hungarian>AGM-Team</Hungarian>
       <Italian>AGM-Team</Italian>
@@ -90,8 +91,8 @@
       <German>Umschalt rechts</German>
       <Spanish>Shift derecho</Spanish>
       <Polish>Prawy Shift</Polish>
-      <French>Shift Droite</French>
       <Czech>Pravý Shift</Czech>
+      <French>Shift Droite</French>
       <Russian>Правый Shift</Russian>
       <Portuguese>Shift da Direita</Portuguese>
       <Hungarian>Jobb Shift</Hungarian>
@@ -102,8 +103,8 @@
       <German>Strg rechts</German>
       <Spanish>Ctrl derecho</Spanish>
       <Polish>Prawy Ctrl</Polish>
-      <French>Ctrl Droite</French>
       <Czech>Pravý Ctrl</Czech>
+      <French>Ctrl Droite</French>
       <Russian>Правый Ctrl</Russian>
       <Portuguese>Ctrl da Direita</Portuguese>
       <Hungarian>Jobb Ctrl</Hungarian>
@@ -114,8 +115,8 @@
       <German>Alt Gr</German>
       <Spanish>Alt derecho</Spanish>
       <Polish>Prawy Alt</Polish>
-      <French>Alt Droite</French>
       <Czech>Pravý Alt</Czech>
+      <French>Alt Droite</French>
       <Russian>Правый Alt</Russian>
       <Portuguese>Alt da Direita</Portuguese>
       <Hungarian>Alt Gr</Hungarian>
@@ -126,8 +127,8 @@
       <German>Standard</German>
       <Spanish>Por defecto</Spanish>
       <Polish>Domyślne</Polish>
-      <French>Défaut</French>
       <Czech>Výchozí</Czech>
+      <French>Défaut</French>
       <Russian>По умолчанию</Russian>
       <Portuguese>Padrão</Portuguese>
       <Hungarian>Alapértelmezett</Hungarian>
@@ -138,8 +139,8 @@
       <German>Keiner</German>
       <Spanish>Ninguna</Spanish>
       <Polish>Brak</Polish>
-      <French>Aucun</French>
       <Czech>Žádný</Czech>
+      <French>Aucun</French>
       <Russian>Не назначено</Russian>
       <Portuguese>Nenhuma</Portuguese>
       <Hungarian>Semmi</Hungarian>
@@ -150,8 +151,8 @@
       <German>2x %1</German>
       <Spanish>2x %1</Spanish>
       <Polish>2x %1</Polish>
-      <French>2x %1</French>
       <Czech>2x %1</Czech>
+      <French>2x %1</French>
       <Russian>2x %1</Russian>
       <Portuguese>2x %1</Portuguese>
       <Hungarian>2x %1</Hungarian>
@@ -162,8 +163,8 @@
       <German>%1 halten</German>
       <Spanish>Mantener %1</Spanish>
       <Polish>Przytrzymać %1</Polish>
-      <French>Tenir %1</French>
       <Czech>Držet %1</Czech>
+      <French>Tenir %1</French>
       <Russian>Удерживая %1</Russian>
       <Portuguese>Segurar %1</Portuguese>
       <Hungarian>%1 Nyomvatartása</Hungarian>
@@ -390,11 +391,11 @@
       <English>Action cancelled.</English>
       <German>Aktion abgebrochen.</German>
       <Spanish>Acción cancelada.</Spanish>
-      <French>Action annulée.</French>
       <Polish>Przerwano czynność</Polish>
+      <Czech>Akce přerušena</Czech>
+      <French>Action annulée.</French>
       <Russian>Действие отменено.</Russian>
       <Portuguese>Ação cancelada.</Portuguese>
-      <Czech>Akce přerušena</Czech>
       <Hungarian>Művelet megszakítva.</Hungarian>
       <Italian>Azione cancellata.</Italian>
     </Key>
@@ -403,11 +404,11 @@
       <German>&lt; Zurück</German>
       <Spanish>&lt; Anterior.</Spanish>
       <Polish>&lt; Poprzedni</Polish>
+      <Czech>&lt; Předchozí</Czech>
       <French>&lt; Préc</French>
-      <Hungarian>&lt; Előző</Hungarian>
       <Russian>&lt; Пред.</Russian>
       <Portuguese>&lt; Anterior</Portuguese>
-      <Czech>&lt; Předchozí</Czech>
+      <Hungarian>&lt; Előző</Hungarian>
       <Italian>&lt; Prec</Italian>
     </Key>
     <Key ID="STR_AGM_Core_Next">
@@ -415,19 +416,19 @@
       <German>Weiter &gt;</German>
       <Spanish>Siguiente &gt;</Spanish>
       <Polish>Następny &gt;</Polish>
+      <Czech>Další &gt;</Czech>
       <French>Suivant &gt;</French>
-      <Hungarian>Következő &gt;</Hungarian>
       <Russian>След. &gt;</Russian>
       <Portuguese>Próximo &gt;</Portuguese>
-      <Czech>Další &gt;</Czech>
+      <Hungarian>Következő &gt;</Hungarian>
       <Italian>Prossimo &gt;</Italian>
     </Key>
     <Key ID="STR_AGM_Core_MiscItems">
       <English>[AGM] Miscellaneous Items</English>
       <German>[AGM] Verschiedenes</German>
       <Spanish>[AGM] Objetos varios</Spanish>
-      <Czech>[AGM] Ostatní předměty</Czech>
       <Polish>[AGM] Różne przedmioty</Polish>
+      <Czech>[AGM] Ostatní předměty</Czech>
       <French>[AGM] Objets divers</French>
       <Russian>[AGM] Различные предметы</Russian>
       <Portuguese>[AGM] Itens diversos</Portuguese>
@@ -437,32 +438,30 @@
     <Key ID="STR_AGM_Core_EnableNumberHotkeys">
       <English>Disable Command Menu</English>
       <German>Befehlsmenü ausschalten</German>
-      <French>Désactiver Menu Commande</French>
-      <Czech>Vypnout velící menu</Czech>
-      <Polish>Wyłącz menu dowodzenia</Polish>
       <Spanish>Desactivar menú de mando</Spanish>
+      <Polish>Wyłącz menu dowodzenia</Polish>
+      <Czech>Vypnout velící menu</Czech>
+      <French>Désactiver Menu Commande</French>
       <Russian>Выключить командное меню</Russian>
       <Hungarian>Parancsnoki menü kikapcsolása</Hungarian>
     </Key>
-
     <Key ID="STR_AGM_Core_Unknown">
       <English>Unknown</English>
       <German>Unbekannt</German>
       <Spanish>Desconocido</Spanish>
       <Polish>Nieznany</Polish>
       <Czech>Neznámý</Czech>
-      <Hungarian>Ismeretlen</Hungarian>
       <Russian>Неизвестно</Russian>
+      <Hungarian>Ismeretlen</Hungarian>
     </Key>
-
     <Key ID="STR_AGM_Core_NoVoice">
       <English>No Voice</English>
       <German>Keine Stimme</German>
       <Spanish>Sin voz</Spanish>
-      <Czech>Žádný hlas</Czech>
-      <Hungarian>Nincs hang</Hungarian>
-      <Russian>Без голоса</Russian>
       <Polish>Brak głosu</Polish>
+      <Czech>Žádný hlas</Czech>
+      <Russian>Без голоса</Russian>
+      <Hungarian>Nincs hang</Hungarian>
     </Key>
   </Package>
 </Project>


### PR DESCRIPTION
Also deleted unnecessary line breaks and made the language listing order consistent between all strings.
