### PR TITLE
Removed the redundant RU string from Core

### DIFF
--- a/AGM_Core/stringtable.xml
+++ b/AGM_Core/stringtable.xml
@@ -13,7 +13,6 @@
       <Portuguese>AGM-Team</Portuguese>
       <Hungarian>AGM-Team</Hungarian>
       <Italian>AGM-Team</Italian>
-      <Russian>Команда AGM</Russian>
     </Key>
     <Key ID="STR_AGM_Core_Save">
       <English>Save</English>


### PR DESCRIPTION
Most likely my own mistake from one of the earlier commits.

It prevented tabler—being very strict about the XML schema—from opening the file and AGM directory altogether. Glad it did, else I would have missed this error.
