### PR TITLE
Move all health simulation to a single thread: AGM_Medical_fnc_simulateHealth.

### DIFF
--- a/AGM_Medical/config.cpp
+++ b/AGM_Medical/config.cpp
@@ -36,6 +36,7 @@ class CfgFunctions {
       class scream;
       class setDamage;
       class setHitPointDamage;
+      class simulateHealth;
       class takeItem;
       class transport;
       class treat;

--- a/AGM_Medical/functions/fn_diagnose.sqf
+++ b/AGM_Medical/functions/fn_diagnose.sqf
@@ -102,10 +102,10 @@ _string = _string + (switch True do {
 });
 
 // Painkillers
-_painkiller = _unit getVariable ["AGM_Painkiller", 1];
+_painkiller = _unit getVariable ["AGM_Painkiller", 0];
 _string = _string + (switch True do {
-  case (_painkiller < 0.4): {"<br/><br/><t color='#FF0000'>" + localize "STR_AGM_Medical_PatientPainkillers" + "</t> "};
-  case (_painkiller < 0.9): {"<br/><br/><t color='#FFFF00'>" + localize "STR_AGM_Medical_PatientSomePainkillers" + "</t> "};
+  case (_painkiller > 0.6): {"<br/><br/><t color='#FF0000'>" + localize "STR_AGM_Medical_PatientPainkillers" + "</t> "};
+  case (_painkiller > 0.1): {"<br/><br/><t color='#FFFF00'>" + localize "STR_AGM_Medical_PatientSomePainkillers" + "</t> "};
   default                   {"<br/><br/>" + localize "STR_AGM_Medical_PatientNoPainkillers" + " "};
 });
 

--- a/AGM_Medical/functions/fn_init.sqf
+++ b/AGM_Medical/functions/fn_init.sqf
@@ -25,7 +25,7 @@ _unit setVariable ["AGM_isTreatable", True, True];    // Can unit be treated/dia
 
 _unit setVariable ["AGM_Blood", 1, True];             // Amount of blood in the body.
 _unit setVariable ["AGM_isBleeding", False, True];    // Is the unit losing blood? (Rate is determined by damage.)
-_unit setVariable ["AGM_Painkiller", 1, True];        // How much painkillers the guy is on. (smaller = more)
+_unit setVariable ["AGM_Painkiller", 0, True];        // How much painkillers the guy is on. (bigger = more)
 _unit setVariable ["AGM_Pain", 0, True];              // Amount of pain the unit is in.
 
 _unit setVariable ["AGM_isUnconscious", False, True]; // figure it out

--- a/AGM_Medical/functions/fn_simulateHealth.sqf
+++ b/AGM_Medical/functions/fn_simulateHealth.sqf
@@ -1,0 +1,90 @@
+/*
+ * Author: KoffeinFlummi, CAA-Picard
+ *
+ * Simulate the health evolution of a unit. Simulates:
+ *   - Blood level
+ *   - Pain  level
+ *   - Morphine level
+ *
+ * Arguments:
+ * 0: Unit to simulate (Object)
+ *
+ * Return value:
+ * None
+ */
+
+#define UNCONSCIOUSNESSTRESHOLD 0.6
+
+#define PAINKILLERTRESHOLD 0.1
+#define PAINLOSS 0.0001
+
+#define BLOODTRESHOLD1 0.35
+#define BLOODTRESHOLD2 0
+#define BLOODLOSSRATE 0.04
+
+private ["_unit", "_script", "_blood", "_pain"];
+
+_unit          = _this select 0;
+
+// Ensure there's only one thread for this
+_script = _unit getVariable ["AGM_simulateHealthScript", scriptNull];
+if (isNull _script) then {
+
+  // Unit is not local, so spawn this thread elsewhere
+  if !(local _unit) exitWith {
+    [[_unit], "AGM_Medical_fnc_simulateHealth", _unit] call AGM_Core_fnc_execRemoteFnc;
+  };
+
+  _unit setVariable ["AGM_simulateHealthScript", _unit spawn {
+    _unit = _this;
+
+    // If the unit is completely healed terminate the loop
+    while {alive _unit and
+           (damage _unit < 1 or
+           _unit getVariable ["AGM_Pain", 0] > 0 or
+           _unit getVariable ["AGM_Painkiller", 0] > 0)
+          } do {
+
+      // Unit has changed locality, so kill this thread and respawn it elsewhere
+      if !(local _unit) exitWith {
+        [[_unit], "AGM_Medical_fnc_simulateHealth", _unit] call AGM_Core_fnc_execRemoteFnc;
+      };
+
+      _blood      = _unit getVariable ["AGM_Blood",      1];
+      _pain       = _unit getVariable ["AGM_Pain",       0];
+      _painkiller = _unit getVariable ["AGM_Painkiller", 0];
+
+      // Bleeding
+      if !([_unit] call AGM_Medical_fnc_isInMedicalVehicle) then {
+        _blood = _blood - BLOODLOSSRATE * (_unit getVariable ["AGM_Medical_CoefBleeding", AGM_Medical_CoefBleeding]) * (damage _unit);
+        _blood = _blood max 0;
+      };
+
+      // Pain Reduction
+      _pain = (_pain - 0.01) max 0;
+
+      // Pain killer Reduction
+      _painkiller = (_painkiller - 0.015) max 0;
+
+
+      _unit setVariable ["AGM_Blood",      _blood,      True];
+      _unit setVariable ["AGM_Pain",       _pain,       True];
+      _unit setVariable ["AGM_Painkiller", _painkiller, True];
+
+
+      // Pass out due to low blood
+      if (_blood <= BLOODTRESHOLD1 and !(_unit getVariable ["AGM_isUnconscious", False])) then {
+        [_unit] call AGM_Medical_fnc_knockOut;
+      };
+
+      // Die from low blood
+      if (_blood <= BLOODTRESHOLD2 and {AGM_Medical_PreventDeathWhileUnconscious == 0}) then {
+        // fx: don't get the uniform bloody if there are no wounds
+        _unit setHitPointDamage ["HitHead", 1];
+      };
+
+      sleep 10;
+    };
+
+  }];
+};

--- a/AGM_Medical/functions/fn_treatmentCallback.sqf
+++ b/AGM_Medical/functions/fn_treatmentCallback.sqf
@@ -61,29 +61,22 @@ switch (_type) do {
   case "morphine" : {
     private ["_painkillerOld", "_painkiller"];
 
-    _painkillerOld = _target getVariable ["AGM_Painkiller", 1];
-
     // reduce pain, pain sensitivity
-    _painkiller = (_painkillerOld - MORPHINEHEAL) max 0;
+    _painkillerOld = _target getVariable ["AGM_Painkiller", 0];
+
+    // overdose if necessary (unit was already full of painkillers)
+    if (_painkillerOld > 0.95 and _target getVariable ["AGM_Medical_EnableOverdosing", AGM_Medical_EnableOverdosing] > 0) then {
+      [_target] call AGM_Medical_fnc_overdose;
+    };
+
+    _painkiller = (_painkillerOld + MORPHINEHEAL) min 1;
     _pain = ((_target getVariable ["AGM_Pain", 0]) - MORPHINEHEAL) max 0;
     _target setVariable ["AGM_Painkiller", _painkiller, True];
     _target setVariable ["AGM_Pain", _pain, True];
 
-    // overdose if necessary (unit was already full of painkillers)
-    if (_painkillerOld < 0.05 and _target getVariable ["AGM_Medical_EnableOverdosing", AGM_Medical_EnableOverdosing] > 0) then {
-      [_target] call AGM_Medical_fnc_overdose;
-    };
 
     // Painkiller Reduction
-    if (_painkillerOld == 1) then {
-      _target spawn {
-        while {_this getVariable ["AGM_Painkiller", 1] < 1} do {
-          sleep 1;
-          _painkiller = ((_this getVariable ["AGM_Painkiller", 1]) + 0.0015) min 1;
-          _this setVariable ["AGM_Painkiller", _painkiller, True];
-        };
-      };
-    };
+    [_target] call AGM_Medical_fnc_simulateHealth;
   };
 
   case "epipen" : {


### PR DESCRIPTION
**WIP**

The idea behind this is concentrating all the variables that control health evolution for a unit on a single loop. Advantages:
* Removing some content from handleDamage that is not related to handling damage
* Reducing the number of spawned threads for medical
* Provide a place to easily add complexity to medical if required
* Allows adding some interactions between medical variables: e.g., increase bleedout rate when you injected epinephrine

Also, changed AGM_Painkillers: 0=none, 1=more