### PR TITLE
AGM_Parameters rewrite

### DIFF
--- a/AGM_Core/functions/fn_disableUserInput.sqf
+++ b/AGM_Core/functions/fn_disableUserInput.sqf
@@ -65,7 +65,7 @@ if (_state) then {
     if (_key in actionKeys "CuratorInterface" && {getAssignedCuratorLogic player in allCurators})    then {(uiNamespace getVariable ["AGM_Core_dlgDisableMouse", displayNull]) closeDisplay 0; openCuratorInterface};
     if (_key in actionKeys "ShowMap"          && {player getVariable ["AGM_canSwitchUnits", false]}) then {(uiNamespace getVariable ["AGM_Core_dlgDisableMouse", displayNull]) closeDisplay 0; openMap true};
 
-    if (serverCommandAvailable "#missions" || {player getVariable ["AGM_isUnconscious", false] && {(call AGM_Core_fnc_player) getVariable ["AGM_Medical_AllowChatWhileUnconscious", missionNamespace getVariable ["AGM_Medical_AllowChatWhileUnconscious", 0]] > 0}})  then {
+    if (serverCommandAvailable "#missions" || {player getVariable ["AGM_isUnconscious", false] && {(call AGM_Core_fnc_player) getVariable ["AGM_Medical_AllowChatWhileUnconscious", missionNamespace getVariable ["AGM_Medical_AllowChatWhileUnconscious", false]]}})  then {
       if (!(_key in (actionKeys "DefaultAction" + actionKeys "Throw")) && {_key in (actionKeys "Chat" + actionKeys "PrevChannel" + actionKeys "NextChannel")}) then {
         _key = 0;
       };

--- a/AGM_Core/functions/fn_setParameter.sqf
+++ b/AGM_Core/functions/fn_setParameter.sqf
@@ -16,5 +16,12 @@
 _name = _this select 0;
 _value = _this select 1;
 
+// Hack to keep backward compatibility for the moment
+if ((typeName (missionNamespace getVariable _name)) == "BOOL") then {
+  if ((typeName _value) == "SCALAR") then {
+    _value = _value > 0;
+  };
+};
+
 missionNamespace setVariable [_name, _value];
 publicVariable _name;

--- a/AGM_Core/scripts/readParameters.sqf
+++ b/AGM_Core/scripts/readParameters.sqf
@@ -18,7 +18,7 @@ for "_index" from 0 to (_count - 1) do {
 
   _name = configName _x;
   _value = _x call bis_fnc_getcfgdata;
-  [_name, _value > 0] call AGM_Core_fnc_setParameter;
+  [_name, _value] call AGM_Core_fnc_setParameter;
 };
 
 _config = configFile >> "AGM_Parameters_Boolean";

--- a/AGM_Core/scripts/readParameters.sqf
+++ b/AGM_Core/scripts/readParameters.sqf
@@ -11,6 +11,27 @@ for "_index" from 0 to (_count - 1) do {
   [_name, _value] call AGM_Core_fnc_setParameter;
 };
 
+_config = configFile >> "AGM_Parameters_Numeric";
+_count = count _config;
+for "_index" from 0 to (_count - 1) do {
+  _x = _config select _index;
+
+  _name = configName _x;
+  _value = _x call bis_fnc_getcfgdata;
+  [_name, _value > 0] call AGM_Core_fnc_setParameter;
+};
+
+_config = configFile >> "AGM_Parameters_Boolean";
+_count = count _config;
+for "_index" from 0 to (_count - 1) do {
+  _x = _config select _index;
+
+  _name = configName _x;
+  _value = _x call bis_fnc_getcfgdata;
+  [_name, _value > 0] call AGM_Core_fnc_setParameter;
+};
+
+
 // Read AGM_Parameters from mission and set them on the mission namespace, replacing defaults if necesary
 _config = missionConfigFile >> "AGM_Parameters";
 _count = count _config;
@@ -20,4 +41,24 @@ for "_index" from 0 to (_count - 1) do {
   _name = configName _x;
   _value = _x call bis_fnc_getcfgdata;
   [_name, _value] call AGM_Core_fnc_setParameter;
+};
+
+_config = missionConfigFile >> "AGM_Parameters_Numeric";
+_count = count _config;
+for "_index" from 0 to (_count - 1) do {
+  _x = _config select _index;
+
+  _name = configName _x;
+  _value = _x call bis_fnc_getcfgdata;
+  [_name, _value] call AGM_Core_fnc_setParameter;
+};
+
+_config = missionConfigFile >> "AGM_Parameters_Boolean";
+_count = count _config;
+for "_index" from 0 to (_count - 1) do {
+  _x = _config select _index;
+
+  _name = configName _x;
+  _value = _x call bis_fnc_getcfgdata;
+  [_name, _value > 0] call AGM_Core_fnc_setParameter;
 };

--- a/AGM_Explosives/config.cpp
+++ b/AGM_Explosives/config.cpp
@@ -293,7 +293,7 @@ class CfgActions {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Boolean {
   // Boolean Parameters (0/1)
   AGM_Explosives_RequireSpecialist = 0;
   AGM_Explosives_PunishNonSpecialists = 1;

--- a/AGM_Explosives/functions/fn_CanDefuse.sqf
+++ b/AGM_Explosives/functions/fn_CanDefuse.sqf
@@ -20,7 +20,7 @@ _unit = _this select 0;
 if (vehicle _unit != _unit || {!("AGM_DefusalKit" in (items _unit))}) exitWith {false};
 _isSpecialist = ([_unit] call AGM_Core_fnc_isEOD);
 
-if ((AGM_Explosives_RequireSpecialist > 0) && {!_isSpecialist}) exitWith {false};
+if (AGM_Explosives_RequireSpecialist && {!_isSpecialist}) exitWith {false};
 
 _timeBombCore = nearestObject [_unit, "TimeBombCore"];
 _mineBase =  nearestObject [_unit, "MineBase"];

--- a/AGM_Explosives/functions/fn_SetupExplosive.sqf
+++ b/AGM_Explosives/functions/fn_SetupExplosive.sqf
@@ -28,7 +28,7 @@ _this spawn {
   AGM_Explosives_placer = _unit;
   // Commented out due to the fact there is a distinction between who can deactivate mines and who can plant them in standard configs.
   // Would require custom config entries (AGM_ExplosiveSpecialist/AGM_Specialist) which excludes custom mods.
-  //if ((AGM_Explosives_RequireSpecialist > 0) && {!([_unit] call AGM_Core_fnc_isEOD)}) exitWith {};
+  //if (AGM_Explosives_RequireSpecialist && {!([_unit] call AGM_Core_fnc_isEOD)}) exitWith {};
   if (isNil "_config") then {
     _config = getArray(ConfigFile >> "CfgMagazines" >> _class >> "AGM_Triggers" >> "AGM_Triggers") select 0;
   };

--- a/AGM_Explosives/functions/fn_StartDefuse.sqf
+++ b/AGM_Explosives/functions/fn_StartDefuse.sqf
@@ -28,7 +28,7 @@ _fnc_DefuseTime = {
   if (isNumber(ConfigFile >> "CfgAmmo" >> typeOf (_target) >> "AGM_DefuseTime")) then {
     _defuseTime = getNumber(ConfigFile >> "CfgAmmo" >> typeOf (_target) >> "AGM_DefuseTime");
   };
-  if (!(_this select 0) && {AGM_Explosives_PunishNonSpecialists > 0}) then {
+  if (!(_this select 0) && {AGM_Explosives_PunishNonSpecialists}) then {
     _defuseTime = _defuseTime * 1.5;
   };
   _defuseTime
@@ -55,7 +55,7 @@ if (AGM_player != _unit) then {
   };
 } else {
   _unit playActionNow _actionToPlay;
-  if (AGM_Explosives_RequireSpecialist > 0) then {
+  if (AGM_Explosives_RequireSpecialist) then {
     if ([_unit] call AGM_Core_fnc_isEOD) then {
       [[true, _target] call _fnc_DefuseTime, [_unit,_target], "AGM_Explosives_fnc_DefuseExplosive", localize "STR_AGM_Explosives_DefusingExplosive"] call AGM_Core_fnc_progressBar;
     };

--- a/AGM_Logistics/config.cpp
+++ b/AGM_Logistics/config.cpp
@@ -1324,7 +1324,7 @@ class CfgWeapons {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Numeric {
   AGM_Repair_TimeRepair = 10;
   AGM_Repair_TimeWheelRepair = 10;
   AGM_Repair_TimeTrackRepair = 10;

--- a/AGM_MagazineRepack/config.cpp
+++ b/AGM_MagazineRepack/config.cpp
@@ -42,7 +42,7 @@ class CfgVehicles {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Numeric {
   AGM_MagazineRepack_TimePerAmmo = 1.5;
   AGM_MagazineRepack_TimePerMagazine = 2.0;
 };

--- a/AGM_Map/clientInit.sqf
+++ b/AGM_Map/clientInit.sqf
@@ -3,8 +3,6 @@
 if (!hasInterface) exitWith{};
 
 [] spawn {
-  if (isNil "AGM_Map_BFT_Enabled") then { AGM_Map_BFT_Enabled = false; };
-  if (isNil "AGM_Map_BFT_HideAiGroups") then { AGM_Map_BFT_HideAiGroups = false; };
   while {true} do {
     sleep 5;
     _markers = [];

--- a/AGM_Map/clientInit.sqf
+++ b/AGM_Map/clientInit.sqf
@@ -12,7 +12,7 @@ if (!hasInterface) exitWith{};
       _groups = [];
       _playerSide = call AGM_Core_fnc_playerSide;
 
-      if (AGM_Map_BFT_HideAiGroups == 0) then {
+      if (AGM_Map_BFT_HideAiGroups) then {
         _groups = [allGroups, {side _this == _playerSide}] call AGM_Core_fnc_filter;
       } else {
         _groups = [allGroups, {

--- a/AGM_Map/config.cpp
+++ b/AGM_Map/config.cpp
@@ -416,6 +416,8 @@ class AGM_Parameters_Numeric {
 };
 class AGM_Parameters_Boolean {
   AGM_Map_EveryoneCanDrawOnBriefing = 1;
+  AGM_Map_BFT_Enabled = 0;
+  AGM_Map_BFT_HideAiGroups = 0;
 };
 
 #include "MapGpsUI.hpp"

--- a/AGM_Map/config.cpp
+++ b/AGM_Map/config.cpp
@@ -411,8 +411,10 @@ class CfgMarkers {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Numeric {
   AGM_Map_BFT_Interval = 1;
+};
+class AGM_Parameters_Boolean {
   AGM_Map_EveryoneCanDrawOnBriefing = 1;
 };
 

--- a/AGM_Map/functions/fn_canDraw.sqf
+++ b/AGM_Map/functions/fn_canDraw.sqf
@@ -1,4 +1,4 @@
 // by CAA-Picard
 
-(missionNameSpace getVariable ["AGM_Map_syncMarkers", true] && {AGM_Map_EveryoneCanDrawOnBriefing > 0}) ||
+(missionNameSpace getVariable ["AGM_Map_syncMarkers", true] && {AGM_Map_EveryoneCanDrawOnBriefing}) ||
 {(!isNull player) && {"AGM_MapTools" in items player}}

--- a/AGM_Medical/config.cpp
+++ b/AGM_Medical/config.cpp
@@ -223,64 +223,64 @@ class CfgVehicles {
         };
         class AGM_Bandage {
           displayName = "$STR_AGM_Medical_Bandage";
-          condition = "AGM_Medical_SingleBandage > 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'All'] call AGM_Medical_fnc_treat;";
           priority = 0.6;
-          conditionShow = "AGM_Medical_SingleBandage > 0";
+          conditionShow = "AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\body.paa";
         };
         class AGM_Bandage_Head {
           displayName = "$STR_AGM_Medical_Bandage_HitHead";
-          condition = "AGM_Medical_SingleBandage == 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "!AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'HitHead'] call AGM_Medical_fnc_treat;";
           priority = 0.6;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\head.paa";
         };
         class AGM_Bandage_Body {
           displayName = "$STR_AGM_Medical_Bandage_HitBody";
-          condition = "AGM_Medical_SingleBandage == 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "!AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'HitBody'] call AGM_Medical_fnc_treat;";
           priority = 0.5;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\body.paa";
         };
         class AGM_Bandage_LeftArm {
           displayName = "$STR_AGM_Medical_Bandage_HitLeftArm";
-          condition = "AGM_Medical_SingleBandage == 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "!AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'HitLeftArm'] call AGM_Medical_fnc_treat;";
           priority = 0.4;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\arm_left.paa";
         };
         class AGM_Bandage_RightArm {
           displayName = "$STR_AGM_Medical_Bandage_HitRightArm";
-          condition = "AGM_Medical_SingleBandage == 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "!AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'HitRightArm'] call AGM_Medical_fnc_treat;";
           priority = 0.3;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\arm_right.paa";
         };
         class AGM_Bandage_LeftLeg {
           displayName = "$STR_AGM_Medical_Bandage_HitLeftLeg";
-          condition = "AGM_Medical_SingleBandage == 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "!AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'HitLeftLeg'] call AGM_Medical_fnc_treat;";
           priority = 0.2;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\leg_left.paa";
         };
         class AGM_Bandage_RightLeg {
           displayName = "$STR_AGM_Medical_Bandage_HitRightLeg";
-          condition = "AGM_Medical_SingleBandage == 0 and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
+          condition = "!AGM_Medical_SingleBandage and ([_target] call AGM_Medical_fnc_isDiagnosed) and (_target getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player and alive _target";
           statement = "[_player, _target, 'bandage', 'HitRightLeg'] call AGM_Medical_fnc_treat;";
           priority = 0.15;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\leg_right.paa";
         };
@@ -339,55 +339,55 @@ class CfgVehicles {
 
         class AGM_Bandage {
           displayName = "$STR_AGM_Medical_Bandage";
-          condition = "AGM_Medical_SingleBandage > 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'All'] call AGM_Medical_fnc_treat;";
           priority = 0.6;
-          conditionShow = "AGM_Medical_SingleBandage > 0";
+          conditionShow = "AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\body.paa";
         };
         class AGM_Bandage_Head {
           displayName = "$STR_AGM_Medical_Bandage_HitHead";
-          condition = "AGM_Medical_SingleBandage == 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "!AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'HitHead'] call AGM_Medical_fnc_treat;";
           priority = 0.6;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\head.paa";
         };
         class AGM_Bandage_Body {
           displayName = "$STR_AGM_Medical_Bandage_HitBody";
-          condition = "AGM_Medical_SingleBandage == 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "!AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'HitBody'] call AGM_Medical_fnc_treat;";
           priority = 0.5;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\body.paa";
         };
         class AGM_Bandage_LeftArm {
           displayName = "$STR_AGM_Medical_Bandage_HitLeftArm";
-          condition = "AGM_Medical_SingleBandage == 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "!AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'HitLeftArm'] call AGM_Medical_fnc_treat;";
           priority = 0.4;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\arm_left.paa";
         };
         class AGM_Bandage_RightArm {
           displayName = "$STR_AGM_Medical_Bandage_HitRightArm";
-          condition = "AGM_Medical_SingleBandage == 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "!AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'HitRightArm'] call AGM_Medical_fnc_treat;";
           priority = 0.3;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\arm_right.paa";
         };
         class AGM_Bandage_LeftLeg {
           displayName = "$STR_AGM_Medical_Bandage_HitLeftLeg";
-          condition = "AGM_Medical_SingleBandage == 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "!AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'HitLeftLeg'] call AGM_Medical_fnc_treat;";
           priority = 0.2;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\leg_left.paa";
         };
@@ -1047,12 +1047,14 @@ class ImpactEffectsBlood {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Numeric {
   AGM_Medical_CoefDamage = 1.0;
   AGM_Medical_CoefBleeding = 1.0;
   AGM_Medical_CoefPain = 1.0;
   AGM_Medical_CoefNonMedic = 2.0;
   AGM_Medical_MaxUnconsciousnessTime = -1;
+};
+class AGM_Parameters_Boolean {
   // Boolean Parameters (0/1)
   AGM_Medical_AllowNonMedics = 0;
   AGM_Medical_RequireDiagnosis = 0;

--- a/AGM_Medical/config.cpp
+++ b/AGM_Medical/config.cpp
@@ -393,10 +393,10 @@ class CfgVehicles {
         };
         class AGM_Bandage_RightLeg {
           displayName = "$STR_AGM_Medical_Bandage_HitRightLeg";
-          condition = "AGM_Medical_SingleBandage == 0 and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
+          condition = "!AGM_Medical_SingleBandage and (_player getVariable ['AGM_isTreatable', true]) and 'AGM_Bandage' in itemsWithMagazines _player";
           statement = "[_player, _player, 'bandage', 'HitRightLeg'] call AGM_Medical_fnc_treat;";
           priority = 0.15;
-          conditionShow = "AGM_Medical_SingleBandage == 0";
+          conditionShow = "!AGM_Medical_SingleBandage";
           enableInside = 1;
           icon = "AGM_Medical\UI\parts\leg_right.paa";
         };

--- a/AGM_Medical/functions/fn_aiCanTreat.sqf
+++ b/AGM_Medical/functions/fn_aiCanTreat.sqf
@@ -22,12 +22,12 @@ switch (_task) do {
   case ("epipen"): {
     _result = _patient getVariable ["AGM_isUnconscious", false]
       && {"AGM_Epipen" in items _medic}
-      && {[_medic] call AGM_Core_fnc_isMedic || {_patient getVariable ["AGM_Medical_AllowNonMedics", AGM_Medical_AllowNonMedics > 0]}}
-      && {!(_medic getVariable ["AGM_Medical_RequireMEDEVAC", AGM_Medical_RequireMEDEVAC > 0])}
+      && {[_medic] call AGM_Core_fnc_isMedic || {_patient getVariable ["AGM_Medical_AllowNonMedics", AGM_Medical_AllowNonMedics]}}
+      && {!(_medic getVariable ["AGM_Medical_RequireMEDEVAC", AGM_Medical_RequireMEDEVAC])}
   };
   case ("bloodbag"): {
     _result = _patient getVariable ["AGM_Blood", 1] < 1
-      && {[_medic] call AGM_Core_fnc_isMedic || {_patient getVariable ["AGM_Medical_AllowNonMedics", AGM_Medical_AllowNonMedics > 0]}}
+      && {[_medic] call AGM_Core_fnc_isMedic || {_patient getVariable ["AGM_Medical_AllowNonMedics", AGM_Medical_AllowNonMedics]}}
   };
 };
 _result

--- a/AGM_Medical/functions/fn_diagnose.sqf
+++ b/AGM_Medical/functions/fn_diagnose.sqf
@@ -26,7 +26,7 @@ _damages = [
 _unit setVariable ["AGM_isDiagnosed", True, False];
 
 // Tell bystanders what's up if necessary
-if (AGM_Medical_RequireDiagnosis > 0) then {
+if (AGM_Medical_RequireDiagnosis) then {
   _bystanders = nearestObjects [AGM_player, ["CAManBase"], 10];
   [-1, {
     if (AGM_player in (_this select 1)) then {
@@ -52,7 +52,7 @@ if (_unit getVariable ["AGM_isUnconscious", False]) then {
 // Injuries
 _lightinjuries = "";
 _heavyinjuries = "";
-if (AGM_Medical_SingleBandage > 0) then {
+if (AGM_Medical_SingleBandage) then {
   _string = _string + (switch True do {
     case (damage _unit >= 0.5): {"<br/><br/><t color='#FF0000'>" + localize "STR_AGM_Medical_PatientHeavilyInjured" + "</t>"};
     case (damage _unit < 0.5):  {"<br/><br/><t color='#FFFF00'>" + localize "STR_AGM_Medical_PatientLightlyInjured" + "</t>"};
@@ -87,7 +87,7 @@ if (AGM_Medical_SingleBandage > 0) then {
 };
 
 // Bleeding
-if ((AGM_Medical_SingleBandage > 0 and damage _unit > 0) or (_heavyinjuries != "" or _lightinjuries != "")) then {
+if ((AGM_Medical_SingleBandage and damage _unit > 0) or (_heavyinjuries != "" or _lightinjuries != "")) then {
   _string = _string + "<br/><br/><t color='#FF0000'>" + localize "STR_AGM_Medical_PatientBleeding" + "</t> ";
 } else {
   _string = _string + "<br/><br/>" + localize "STR_AGM_Medical_PatientNotBleeding" + " ";

--- a/AGM_Medical/functions/fn_handleDamage.sqf
+++ b/AGM_Medical/functions/fn_handleDamage.sqf
@@ -88,11 +88,11 @@ if (diag_frameno > (_unit getVariable ["AGM_Medical_FrameNo", -3]) + 2) then {
   _unit setVariable ["AGM_Medical_PreventDeath", False];
   if (([_unit] call AGM_Core_fnc_isPlayer) or _unit getVariable ["AGM_allowUnconscious", False]) then {
     if (!(_unit getVariable ["AGM_isUnconscious", False]) and
-        {_unit getVariable ["AGM_Medical_PreventInstaDeath", AGM_Medical_PreventInstaDeath > 0]}) then {
+        {_unit getVariable ["AGM_Medical_PreventInstaDeath", AGM_Medical_PreventInstaDeath]}) then {
       _unit setVariable ["AGM_Medical_PreventDeath", True];
     };
     if ((_unit getVariable ["AGM_isUnconscious", False]) and
-        {_unit getVariable ["AGM_Medical_PreventDeathWhileUnconscious", AGM_Medical_PreventDeathWhileUnconscious > 0]}) then {
+        {_unit getVariable ["AGM_Medical_PreventDeathWhileUnconscious", AGM_Medical_PreventDeathWhileUnconscious]}) then {
       _unit setVariable ["AGM_Medical_PreventDeath", True];
     };
   };
@@ -230,7 +230,7 @@ if (_selectionName == "" and damage _unit == 0) then {
         if (_blood <= BLOODTRESHOLD1 and !(_this getVariable ["AGM_isUnconscious", False])) then {
           [_this] call AGM_Medical_fnc_knockOut;
         };
-        if (_blood <= BLOODTRESHOLD2 and {AGM_Medical_PreventDeathWhileUnconscious == 0}) then {
+        if (_blood <= BLOODTRESHOLD2 and {!AGM_Medical_PreventDeathWhileUnconscious}) then {
           //_this setDamage 1;
           _this setHitPointDamage ["HitHead", 1]; // fx: don't get the uniform bloody if there are no wounds
         };

--- a/AGM_Medical/functions/fn_isDiagnosed.sqf
+++ b/AGM_Medical/functions/fn_isDiagnosed.sqf
@@ -14,7 +14,7 @@ private ["_unit"];
 
 _unit = _this select 0;
 
-if !(AGM_player getVariable ["AGM_Medical_RequireDiagnosis", AGM_Medical_RequireDiagnosis > 0]) exitWith {true};
+if !(AGM_player getVariable ["AGM_Medical_RequireDiagnosis", AGM_Medical_RequireDiagnosis]) exitWith {true};
 if !(_unit getVariable ["AGM_isUnconscious", False]) exitWith {true};
 
 (_unit getVariable ["AGM_isDiagnosed", True])

--- a/AGM_Medical/functions/fn_knockOut.sqf
+++ b/AGM_Medical/functions/fn_knockOut.sqf
@@ -98,7 +98,7 @@ if (vehicle _unit != _unit) then {
 };
 
 // wake up unit after certain amount of time
-if (_duration != -1 or _unit getVariable ["AGM_Medical_AutomaticWakeup", AGM_Medical_AutomaticWakeup > 0]) then {
+if (_duration != -1 or _unit getVariable ["AGM_Medical_AutomaticWakeup", AGM_Medical_AutomaticWakeup]) then {
   _wakeUpTimer = [_unit, _duration] spawn {
     _unit = _this select 0;
     _duration = _this select 1;

--- a/AGM_Medical/functions/fn_overdose.sqf
+++ b/AGM_Medical/functions/fn_overdose.sqf
@@ -12,7 +12,7 @@
 
 _unit = _this select 0;
 
-if (AGM_Medical_EnableOverdosing < 1) exitWith {};
+if (!AGM_Medical_EnableOverdosing) exitWith {};
 
 if !(local _unit) exitWith {
   [_this, "AGM_Medical_fnc_overdose", _unit] call AGM_Core_fnc_execRemoteFnc;

--- a/AGM_Medical/functions/fn_scream.sqf
+++ b/AGM_Medical/functions/fn_scream.sqf
@@ -12,7 +12,7 @@
 
 private ["_unit", "_screams", "_position"];
 
-if (AGM_Medical_DisableScreams == 1) exitWith {};
+if (AGM_Medical_DisableScreams) exitWith {};
 
 _unit = _this select 0;
 

--- a/AGM_Medical/functions/fn_setHitPointDamage.sqf
+++ b/AGM_Medical/functions/fn_setHitPointDamage.sqf
@@ -66,11 +66,11 @@ if (_damageOld > 0) then {
 };
 
 if (_unit getVariable ["AGM_isUnconscious", False]) then {
-  if (_damageNew > 0.9 and {AGM_Medical_PreventDeathWhileUnconscious > 0}) then {
+  if (_damageNew > 0.9 and {AGM_Medical_PreventDeathWhileUnconscious}) then {
     _damageNew = 0.89;
   };
 } else {
-  if (_damageNew > 0.9 and {AGM_Medical_PreventInstaDeath > 0}) then {
+  if (_damageNew > 0.9 and {AGM_Medical_PreventInstaDeath}) then {
     _damageNew = 0.89;
   };
 };
@@ -80,11 +80,11 @@ _unit setDamage _damageNew;
 {
   _damageFinal = (_damages select _forEachIndex);
   if (_unit getVariable ["AGM_isUnconscious", False]) then {
-    if (_damageFinal > 0.9 and {AGM_Medical_PreventDeathWhileUnconscious > 0}) then {
+    if (_damageFinal > 0.9 and {AGM_Medical_PreventDeathWhileUnconscious}) then {
       _damageFinal = 0.89;
     };
   } else {
-    if (_damageFinal > 0.9 and {AGM_Medical_PreventInstaDeath > 0}) then {
+    if (_damageFinal > 0.9 and {AGM_Medical_PreventInstaDeath}) then {
       _damageFinal = 0.89;
     };
   };

--- a/AGM_Medical/functions/fn_treat.sqf
+++ b/AGM_Medical/functions/fn_treat.sqf
@@ -27,7 +27,7 @@ _type = _this select 2;
 // check if unit is medic and if that's even necessary
 if (_type in ["epipen", "bloodbag"] and
     !(([_unit] call AGM_Core_fnc_isMedic) or
-    (_unit getVariable ["AGM_Medical_AllowNonMedics", AGM_Medical_AllowNonMedics > 0]))) exitWith {
+    (_unit getVariable ["AGM_Medical_AllowNonMedics", AGM_Medical_AllowNonMedics]))) exitWith {
   if ([_unit] call AGM_Core_fnc_isPlayer) then {
     [localize "STR_AGM_Medical_NotTrained"] call AGM_Core_fnc_displayTextStructured;
   };
@@ -44,7 +44,7 @@ _inTrigger = False;
   _inTrigger = _target distance _x < 10;
 } forEach (missionNamespace getVariable ["AGM_Medical_MEDEVACVehicles", []]);
 
-if (_type == "epipen" and (_unit getVariable ["AGM_Medical_RequireMEDEVAC", AGM_Medical_RequireMEDEVAC > 0]) and !_inTrigger) exitWith {
+if (_type == "epipen" and (_unit getVariable ["AGM_Medical_RequireMEDEVAC", AGM_Medical_RequireMEDEVAC]) and !_inTrigger) exitWith {
   if ([_unit] call AGM_Core_fnc_isPlayer) then {
     [localize "STR_AGM_Medical_NotInMEDEVAC"] call AGM_Core_fnc_displayTextStructured;
   };

--- a/AGM_Medical/functions/fn_treatmentCallback.sqf
+++ b/AGM_Medical/functions/fn_treatmentCallback.sqf
@@ -70,7 +70,7 @@ switch (_type) do {
     _target setVariable ["AGM_Pain", _pain, True];
 
     // overdose if necessary (unit was already full of painkillers)
-    if (_painkillerOld < 0.05 and _target getVariable ["AGM_Medical_EnableOverdosing", AGM_Medical_EnableOverdosing] > 0) then {
+    if (_painkillerOld < 0.05 and _target getVariable ["AGM_Medical_EnableOverdosing", AGM_Medical_EnableOverdosing]) then {
       [_target] call AGM_Medical_fnc_overdose;
     };
 

--- a/AGM_NameTags/clientInit.sqf
+++ b/AGM_NameTags/clientInit.sqf
@@ -12,7 +12,7 @@ addMissionEventHandler ["Draw3D", {
     _target = cursorTarget;
     _target = if (_target in allUnitsUAV) then {objNull} else {effectiveCommander _target};
 
-    if (!isNull _target && {side group _target == playerSide} && {_target != _player} && {isPlayer _target || {AGM_NameTags_ShowNamesForAI > 0}} && {!(_target getVariable ["AGM_hideName", false])}) then {
+    if (!isNull _target && {side group _target == playerSide} && {_target != _player} && {isPlayer _target || {AGM_NameTags_ShowNamesForAI}} && {!(_target getVariable ["AGM_hideName", false])}) then {
       _distance = _player distance _target;
       _alpha = ((1 - 0.2 * (_distance - AGM_NameTags_PlayerNamesViewDistance)) min 1) * AGM_NameTags_PlayerNamesMaxAlpha;
       if (profileNamespace getVariable ["AGM_showPlayerNamesOnlyOnKeyPress", false]) then {
@@ -36,7 +36,7 @@ addMissionEventHandler ["Draw3D", {
     {
       _target = if (_x in allUnitsUAV) then {objNull} else {effectiveCommander _x};
 
-      if (!isNull _target && {side group _target == playerSide} && {_target != _player} && {isPlayer _target || {AGM_NameTags_ShowNamesForAI > 0}} && {!(_target getVariable ["AGM_hideName", false])}) then {
+      if (!isNull _target && {side group _target == playerSide} && {_target != _player} && {isPlayer _target || {AGM_NameTags_ShowNamesForAI}} && {!(_target getVariable ["AGM_hideName", false])}) then {
         _relPos = (visiblePositionASL _target) vectorDiff _pos;
         _distance = vectorMagnitude _relPos;
         _projDist = _relPos vectorDistance (_vecy vectorMultiply (_relPos vectorDotProduct _vecy));

--- a/AGM_NameTags/config.cpp
+++ b/AGM_NameTags/config.cpp
@@ -74,11 +74,13 @@ class AGM_Core_Options {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Numeric {
   AGM_NameTags_PlayerNamesViewDistance = 5;
-  AGM_NameTags_ShowNamesForAI = 0;
   AGM_NameTags_PlayerNamesMaxAlpha = 0.8;
   AGM_NameTags_CrewInfoVisibility = 0;
+};
+class AGM_Parameters_Boolean {
+  AGM_NameTags_ShowNamesForAI = 0;
 };
 
 class CfgVehicles {

--- a/AGM_Respawn/config.cpp
+++ b/AGM_Respawn/config.cpp
@@ -274,9 +274,7 @@ class CfgVehicles {
   };
 };
 
-class AGM_Parameters {
-  // Number parameters
-  //AGM_Respawn_BodyRemoveTimer = 90;
+class AGM_Parameters_Boolean {
   // Boolean Parameters (0/1)
   AGM_Respawn_SavePreDeathGear = 0;
   AGM_Respawn_RemoveDeadBodiesDisonncected = 1;

--- a/AGM_Respawn/functions/fn_handleKilled.sqf
+++ b/AGM_Respawn/functions/fn_handleKilled.sqf
@@ -22,7 +22,7 @@ _killedUnit = _this select 0;
 // Saves the gear when the player is killed
 AGM_Respawn_unitGear = [];
 
-if (AGM_Respawn_SavePreDeathGear > 0) then {
+if (AGM_Respawn_SavePreDeathGear) then {
   AGM_Respawn_unitGear = [_killedUnit] call AGM_Respawn_fnc_getAllGear;
 };
 

--- a/AGM_Respawn/functions/fn_handleRespawn.sqf
+++ b/AGM_Respawn/functions/fn_handleRespawn.sqf
@@ -20,6 +20,6 @@ private ["_respawnedUnit"];
 _respawnedUnit = _this select 0;
 
 // Restores the gear when the player respawns
-if (AGM_Respawn_SavePreDeathGear > 0) then {
+if (AGM_Respawn_SavePreDeathGear) then {
   [_respawnedUnit, AGM_Respawn_unitGear] call AGM_Respawn_fnc_restoreGear;
 };

--- a/AGM_Respawn/functions/fn_module.sqf
+++ b/AGM_Respawn/functions/fn_module.sqf
@@ -22,7 +22,7 @@ AGM_Respawn_Module = true;
 [_logic, "AGM_Respawn_RemoveDeadBodiesDisonncected", "RemoveDeadBodiesDisonncected"] call AGM_Core_fnc_readBooleanParameterFromModule;
 
 if (isServer) then {
-	if (AGM_Respawn_RemoveDeadBodiesDisonncected == 1) then {
+	if (AGM_Respawn_RemoveDeadBodiesDisonncected) then {
 		_fnc_deleteDisconnected = {
 			_this spawn {
 				_unit = _this select 0;

--- a/AGM_SwitchUnits/clientInit.sqf
+++ b/AGM_SwitchUnits/clientInit.sqf
@@ -6,17 +6,16 @@
 0 spawn {
   private ["_side"];
   
-  waitUntil {sleep 0.5; !isNil "AGM_SwitchUnits_EnableSwitchUnits"};
-  if (AGM_SwitchUnits_EnableSwitchUnits == 0) exitWith {};
+  waitUntil {sleep 0.5; AGM_SwitchUnits_EnableSwitchUnits};
   
   //_side = [west, east, independent, civilian] select AGM_SwitchUnits_SwitchUnitsAllowedForSide;
   
   _sides = [];
   
-  if(AGM_SwitchUnits_SwitchToWest == 1) then {_sides pushBack west};
-  if(AGM_SwitchUnits_SwitchToEast == 1) then {_sides pushBack east};
-  if(AGM_SwitchUnits_SwitchToIndependent == 1) then {_sides pushBack independent};
-  if(AGM_SwitchUnits_SwitchToCivilian == 1) then {_sides pushBack civilian};
+  if(AGM_SwitchUnits_SwitchToWest) then {_sides pushBack west};
+  if(AGM_SwitchUnits_SwitchToEast) then {_sides pushBack east};
+  if(AGM_SwitchUnits_SwitchToIndependent) then {_sides pushBack independent};
+  if(AGM_SwitchUnits_SwitchToCivilian) then {_sides pushBack civilian};
   
   if (player getVariable ["AGM_CanSwitchUnits", false]) then {
     [player, _sides] call AGM_SwitchUnits_fnc_initPlayer;

--- a/AGM_SwitchUnits/config.cpp
+++ b/AGM_SwitchUnits/config.cpp
@@ -127,12 +127,14 @@ class CfgVehicles {
   };
 };
 
-class AGM_Parameters {
+class AGM_Parameters_Numeric {
+  AGM_SwitchUnits_SafeZoneRadius = 100;
+};
+class AGM_Parameters_Boolean {
   AGM_SwitchUnits_EnableSwitchUnits = 0;
   AGM_SwitchUnits_SwitchToWest = 0;
   AGM_SwitchUnits_SwitchToEast = 0;
   AGM_SwitchUnits_SwitchToIndependent = 0;
   AGM_SwitchUnits_SwitchToCivilian = 0;
   AGM_SwitchUnits_EnableSafeZone = 1;
-  AGM_SwitchUnits_SafeZoneRadius = 100;
 };

--- a/AGM_SwitchUnits/functions/fn_module.sqf
+++ b/AGM_SwitchUnits/functions/fn_module.sqf
@@ -25,7 +25,7 @@ if !(_activated) exitWith {};
 
 AGM_SwitchUnits_Module = true;
 
-["AGM_SwitchUnits_EnableSwitchUnits", 1] call AGM_Core_fnc_setParameter;
+["AGM_SwitchUnits_EnableSwitchUnits", true] call AGM_Core_fnc_setParameter;
 
 [_logic, "AGM_SwitchUnits_SwitchToWest", "SwitchToWest"] call AGM_Core_fnc_readBooleanParameterFromModule;
 [_logic, "AGM_SwitchUnits_SwitchToEast", "SwitchToEast"] call AGM_Core_fnc_readBooleanParameterFromModule;

--- a/AGM_SwitchUnits/functions/fn_switchUnit.sqf
+++ b/AGM_SwitchUnits/functions/fn_switchUnit.sqf
@@ -28,7 +28,7 @@ _newUnit spawn {
   
   _leave = false;
   
-  if (AGM_SwitchUnits_EnableSafeZone == 1) then {
+  if (AGM_SwitchUnits_EnableSafeZone) then {
   
     _allNearestPlayers = [position _unit, AGM_SwitchUnits_SafeZoneRadius] call AGM_SwitchUnits_fnc_nearestPlayers;
     _nearestEnemyPlayers = [_allNearestPlayers, {((side AGM_SwitchUnits_OriginalGroup) getFriend (side _this) < 0.6) && !(_this getVariable ["AGM_SwitchUnits_IsPlayerControlled", false])}] call AGM_Core_fnc_filter;

--- a/AGM_VehicleLock/config.cpp
+++ b/AGM_VehicleLock/config.cpp
@@ -12,8 +12,8 @@ class CfgPatches {
   };
 };
 
-class AGM_Parameters {
-  AGM_VEHICLELOCK_defaultLockpickStrength = 10;
+class AGM_Parameters_Numeric {
+  AGM_VehicleLock_DefaultLockpickStrength = 10;
 };
 
 class CfgFunctions {

--- a/AGM_VehicleLock/functions/fn_lockpick.sqf
+++ b/AGM_VehicleLock/functions/fn_lockpick.sqf
@@ -40,7 +40,7 @@ if (!("AGM_item_key_lockpick" in (items _unit))) exitWith {
   false
 };
 
-_vehLockpickStrenth = _veh getVariable["agm_vehicleLock_pickStr", AGM_VEHICLELOCK_defaultLockpickStrength];
+_vehLockpickStrenth = _veh getVariable["agm_vehicleLock_pickStr", AGM_VehicleLock_DefaultLockpickStrength];
 if (typeName _vehLockpickStrenth != "SCALAR") exitWith {
   ["AGM_VehicleLock_fnc_lockpick: agm_vehicleLock_pickStr invalid: (%1)", _veh] call BIS_fnc_error;
   false

--- a/AGM_VehicleLock/functions/fn_moduleInit.sqf
+++ b/AGM_VehicleLock/functions/fn_moduleInit.sqf
@@ -25,7 +25,7 @@ _this spawn {
   _setLockState = _logic getVariable["SetLockState", 0];
 
   if (isServer) then {
-    [_logic, "AGM_VEHICLELOCK_defaultLockpickStrength", "LockpickStrength"] call AGM_Core_fnc_readNumericParameterFromModule;
+    [_logic, "AGM_VehicleLock_DefaultLockpickStrength", "LockpickStrength"] call AGM_Core_fnc_readNumericParameterFromModule;
 
     { //set lock state
       _lock =

--- a/AGM_VehicleLock/readme.txt
+++ b/AGM_VehicleLock/readme.txt
@@ -26,11 +26,11 @@ Vehicle Lock Setup - Settings for lockpick strength, auto assigment of keys at s
 Vehicle Key Assign - Sync with vehicles and players.  Will handout custom keys to players for every synced vehicle.
 
 Global Variable: 
-AGM_VEHICLELOCK_defaultLockpickStrength - Time in seconds to lock pick globaly, can also set per-vehicle (-1 would disable)
+AGM_VehicleLock_DefaultLockpickStrength - Time in seconds to lock pick globaly, can also set per-vehicle (-1 would disable)
 
 Vehicle setVariables:
 agm_lock_side - SIDE: overrides a vehicle's side, allows indfor to use little-bird's with indp keys
-agm_vehicleLock_pickStr - NUMBER: secons, determines how long lockpicking with take, overrides AGM_VEHICLELOCK_defaultLockpickStrength
+agm_vehicleLock_pickStr - NUMBER: secons, determines how long lockpicking with take, overrides AGM_VehicleLock_DefaultLockpickStrength
 agm_lock_customKeys - ARRAY: array of strings of magazinesDetails, use the following function to modify
 
 [bob, car1, true] call AGM_VehicleLock_fnc_addKeyForVehicle;


### PR DESCRIPTION
On the old implementation there was no way of knowing what variable type should be used for a parameter, so they all were treated like numbers, which lead to things like: 

`if (AGM_Explosives_RequireSpecialist > 0) then ...`

Now the class `AGM_Parameters` is replaced by `AGM_Parameters_Numeric` and `AGM_Parameters_Boolean`, so every parameter has a clearly identified type.

Booleans params are now loaded into proper boolean variables, so the above becomes:

`if (AGM_Explosives_RequireSpecialist) then ...`

The system is meant to be backward compatible, so `AGM_Parameters` entries are still supported. The nice thing is there's a hack that automatically converts description.ext entries if they are on the legacy format.