### PR TITLE
"GROUP" camera type should be considered as an external camera

### DIFF
--- a/AGM_Goggles/functions/fn_ExternalCamera.sqf
+++ b/AGM_Goggles/functions/fn_ExternalCamera.sqf
@@ -1,7 +1,7 @@
 /*
 	Name: AGM_Goggles_fnc_ExternalCamera
 	
-	Author: Garth de Wet (LH)
+	Author: Garth de Wet (LH), Sniperwolf572
 	
 	Description:
 	Returns if the camera is external or not.
@@ -16,4 +16,4 @@
 	call AGM_Goggles_fnc_ExternalCamera;
 */
 if (profileNamespace getVariable ["AGM_showInThirdPerson", false]) exitWith { false };
-(cameraView == "External")
+(cameraView == "EXTERNAL" || cameraView == "GROUP")


### PR DESCRIPTION
Added the "GROUP" type to the external camera check in the AGM_Goggles. 

It's the command camera type, bound to "Numpad Del" by default and only available when the player is the group leader. Just in case someone is not familiar with it. :)