### PR TITLE
Removed cursor and cursorAim for Sidewinders

### DIFF
--- a/AGM_Aircraft/config.cpp
+++ b/AGM_Aircraft/config.cpp
@@ -645,8 +645,6 @@ class CfgWeapons {
     aiRateOfFire = 5;
     aiRateOfFireDistance = 500;
     autoFire = 0;
-    cursor = "EmptyCursor";
-    cursorAim = "missile";
     nameSound = "MissileLauncher";
     textureType = "fullAuto";
     weaponLockDelay = 3;


### PR DESCRIPTION
cursor="EmptyCursor";
cursorAim="missile";

were defined twice with this config. It should be removed, to grant compatibility to Kimi´s HMD,s, which turns off the cursor crosshairs in planes, by simply setting both to "EmptyCursor". This setting was overwritten by this config.