### PR TITLE
set default value and fixed bug in inverted isnil check

### DIFF
--- a/AGM_Logistics/functions/Drag/fn_MakeUndraggable.sqf
+++ b/AGM_Logistics/functions/Drag/fn_MakeUndraggable.sqf
@@ -1,18 +1,18 @@
 /*
  	Name: AGM_Drag_fnc_makeUndraggable
- 	
+
  	Author(s):
 		L-H
 
  	Description:
 		Makes an object undraggable. Also reverses the effects of a AGM_Drag_fnc_makeDraggable call.
-	
+
 	Parameters:
 		0: OBJECT - Object (static weapon, crate, etc.)
- 	
+
  	Returns:
 		Nothing
- 	
+
  	Example:
 		// Remove drag functionality from an object
 		[StaticWeapon2] call AGM_Drag_fnc_makeUndraggable;
@@ -31,8 +31,8 @@ if (_object getVariable ["AGM_inUse", false]) then {
 };
 _object setVariable ["AGM_disableDrag", true, true];
 
-_id = _object getVariable "AGM_dragActionID";
-if (!(isNil "_id") OR {_id != -1}) then {
+_id = _object getVariable ["AGM_dragActionID", -1];
+if (_id != -1) then {
 	_object setVariable ["AGM_dragActionID", -1, true];
 	[_object, _id] call AGM_Interaction_fnc_removeInteraction;
 };


### PR DESCRIPTION
got an error in `AGM_Drag_fnc_makeUndraggable`
```sqf
"22:42:40 Error in expression <M_dragActionID";
if (!(isNil "_id") OR {_id != -1}) then {
_object setVariable [>
22:42:40   Error position: <_id != -1}) then {
_object setVariable [>
22:42:40   Error Undefined variable in expression: _id
22:42:40 File AGM_Logistics\functions\Drag\fn_makeUndraggable.sqf, line 35"
```