### PR TITLE
AGM_Logistics: Spare wheels number control

### DIFF
--- a/AGM_Logistics/scripts/itemsCar.sqf
+++ b/AGM_Logistics/scripts/itemsCar.sqf
@@ -4,11 +4,20 @@ private ["_vehicle", "_item"];
 
 _vehicle = _this select 0;
 
-_item = ['AGM_JerryCan', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
-[_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;
 
-// Do not add spare wheels to light vehicles like quad bikes and karts.
-if (getMass _vehicle >= 1000) then {
-  _item = ['AGM_SpareWheel', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
-  [_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;
+if( missionNamespace getVariable ["AGM_Logistics_PutJerryCan", true]) then {
+	_item = ['AGM_JerryCan', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
+	[_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;
 };
+
+for "_x" from 1 to (missionNamespace getVariable ["AGM_Logistics_SparewheelNumber",1]) do {
+  // Do not add spare wheels to light vehicles like quad bikes and karts.
+  if (getMass _vehicle >= 1000) then {
+    _item = ['AGM_SpareWheel', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
+    [_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;
+  };
+};
+
+
+
+

--- a/AGM_Logistics/scripts/itemsTank.sqf
+++ b/AGM_Logistics/scripts/itemsTank.sqf
@@ -4,8 +4,8 @@ private ["_vehicle", "_item"];
 
 _vehicle = _this select 0;
 
-_item = ['AGM_SpareTrack', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
-[_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;
+for "_x" from 1 to (missionNamespace getVariable ["AGM_Logistics_SpareTrackNumber",2]) do {
+  _item = ['AGM_SpareTrack', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
+  [_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;
+};
 
-_item = ['AGM_SpareTrack', [-1000, -1000, 100]] call AGM_Logistics_fnc_spawnObject;
-[_vehicle, _item] call AGM_Logistics_fnc_initLoadedObject;

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -54,3 +54,4 @@ Adanteh
 Tourorist <tourorist@gmail.com>
 Saforax <saforax@taw.net>
 JonBons <me@mattgraham.me>
+[STELS]Zealot <zealot@red-bear.ru>


### PR DESCRIPTION
Mission makers should have ability to control number of spare wheel in
vehicles and availability of Jerry can. I added variables, which mission makers can change from init.sqf:
```php
//Put Jerry can to vehicles
AGM_Logistics_PutJerryCan = false;
//Number of spare wheels
AGM_Logistics_SparewheelNumber = 1;
//Number of spare tracks
AGM_Logistics_SpareTrackNumber = 2;
```