### PR TITLE
Add a line to prevent interfering with UGL zeroing

### DIFF
--- a/AGM_Scopes/functions/fn_canAdjustScope.sqf
+++ b/AGM_Scopes/functions/fn_canAdjustScope.sqf
@@ -23,6 +23,8 @@ _weapons = [
 
 if !(currentWeapon _unit in _weapons) exitWith {false};
 
+if (currentMuzzle _unit != currentWeapon _unit) exitWith {false};
+
 if (isNil "AGM_Scopes_Adjustment") then {
   AGM_Scopes_Adjustment = [[0,0], [0,0], [0,0]];
 };


### PR DESCRIPTION
Restrict scope adjustment UI to primary muzzle only, preventing trouble with zeroing adjustment of UGLs in occasions like using MX 3GL + LRPS combination and current muzzle is 3GL, pressing PageUp/Down counter-intuitively triggers AGM scope adjustment, instead of 3GL sight adjustment.